### PR TITLE
Add tooltips to show filter descriptions

### DIFF
--- a/src/components/chakra/combobox.tsx
+++ b/src/components/chakra/combobox.tsx
@@ -6,7 +6,6 @@ import {
   Combobox,
   Portal,
   Tag,
-  Text,
   useFilter,
   useListCollection
 } from "@chakra-ui/react";

--- a/src/components/ui/control.tsx
+++ b/src/components/ui/control.tsx
@@ -3,11 +3,13 @@ import { Tab } from "@/components/chakra";
 import {
   type SliderValueChangeDetails,
   Box,
-  Collapsible,
+  Accordion,
   ScrollArea,
   Text,
+  Button,
+  IconButton,
 } from "@chakra-ui/react";
-import { LuChevronUp, LuLayers, LuSettings2 } from "react-icons/lu";
+import { LuChevronUp, LuInfo, LuLayers, LuSettings2 } from "react-icons/lu";
 import { FilterControl } from "./filters/filter-control";
 import { FilterLabel } from "./filters/filter-label";
 import { LayerControl } from "./layers/layer-control";
@@ -17,9 +19,11 @@ import { useFilters } from "@/utils/context/filters";
 import { ApplyActions } from "./apply-actions";
 // FilterType as enum
 import { FilterType, type Filter, type ItemUnit } from "@/app/types";
+import { Tooltip } from "./tooltip";
 
 interface ColGroup {
   title: string;
+  description?: string;
   items: Filter[];
 }
 
@@ -52,7 +56,14 @@ const FilterControlWrapper = memo(function FilterControlWrapper({
     [filter.id, filter.type, setPendingFilters],
   );
 
-  return <FilterControl config={filter} value={value} hasPending={hasPending} onChange={onChange} />;
+  return (
+    <FilterControl
+      config={filter}
+      value={value}
+      hasPending={hasPending}
+      onChange={onChange}
+    />
+  );
 });
 
 const LayersPanel = () => {
@@ -88,27 +99,41 @@ const CollapsibleGroup = memo(function CollapsibleGroup({
 }: {
   collapsibleItem: ColGroup;
 }) {
-  const { displayFilters, setPendingFilters, getFilterPendingStatus } = useFilters();
-  const pendingCount = collapsibleItem.items.filter((f) => getFilterPendingStatus(f.id)).length;
+  const { displayFilters, setPendingFilters, getFilterPendingStatus } =
+    useFilters();
+  const pendingCount = collapsibleItem.items.filter((f) =>
+    getFilterPendingStatus(f.id),
+  ).length;
   return (
-    <Collapsible.Root>
-      <Collapsible.Trigger
+    <Accordion.Item value={collapsibleItem.title}>
+      <Accordion.ItemTrigger
         display="flex"
         gap="2"
         alignItems="center"
-        justifyContent="space-between"
         width="100%"
         textStyle="collapsibleGroupTitle"
       >
-        <FilterLabel title={collapsibleItem.title} hasPending={pendingCount > 0} pendingCount={pendingCount} textStyle="collapsibleGroupTitle" />
-        <Collapsible.Indicator
-          transition="transform 0.2s"
-          _open={{ transform: "rotate(180deg)" }}
-        >
+        <FilterLabel
+          title={collapsibleItem.title}
+          hasPending={pendingCount > 0}
+          pendingCount={pendingCount}
+          textStyle="collapsibleGroupTitle"
+        />
+        {collapsibleItem.items[0].description && (
+          <Tooltip
+            content={collapsibleItem.items[0].description}
+            contentProps={{ css: { "--tooltip-bg": "colors.bg", color: "fg" } }}
+          >
+            <IconButton variant="ghost" size="xs" p={0}>
+              <LuInfo />
+            </IconButton>
+          </Tooltip>
+        )}
+        <Accordion.ItemIndicator ml="auto">
           <LuChevronUp />
-        </Collapsible.Indicator>
-      </Collapsible.Trigger>
-      <Collapsible.Content>
+        </Accordion.ItemIndicator>
+      </Accordion.ItemTrigger>
+      <Accordion.ItemContent>
         <Box mt={1}>
           {collapsibleItem.items?.map((matchingFilter) => (
             <FilterControlWrapper
@@ -119,14 +144,15 @@ const CollapsibleGroup = memo(function CollapsibleGroup({
             />
           ))}
         </Box>
-      </Collapsible.Content>
-    </Collapsible.Root>
+      </Accordion.ItemContent>
+    </Accordion.Item>
   );
 });
 
 const ControlsPanel = () => {
   const { model } = useModel();
-  const { displayFilters, setPendingFilters, getFilterPendingStatus } = useFilters();
+  const { displayFilters, setPendingFilters, getFilterPendingStatus } =
+    useFilters();
   if (!displayFilters) return <div>Please wait</div>;
 
   const adminFilterExists = model.filters.filter(
@@ -156,6 +182,7 @@ const ControlsPanel = () => {
   const noCollapsibleGroups = model.filters.filter(
     (f) => f.type === FilterType.numeric,
   );
+  console.log(collapsibleGroups);
 
   return (
     // To give space for scrollable area
@@ -164,11 +191,17 @@ const ControlsPanel = () => {
         <ScrollArea.Viewport>
           <ScrollArea.Content spaceY="4" pr={4}>
             {/* put collapsible groups first */}
-            {collapsibleGroups.map((group) => (
-              <Box key={group.title}>
-                <CollapsibleGroup collapsibleItem={group} />
-              </Box>
-            ))}
+            <Accordion.Root
+              collapsible
+              multiple
+              defaultValue={["b"]}
+              size="sm"
+              variant="plain"
+            >
+              {collapsibleGroups.map((group) => (
+                <CollapsibleGroup collapsibleItem={group} key={group.title} />
+              ))}
+            </Accordion.Root>
 
             {/* numeric data doesn't need to be collapsible */}
             {noCollapsibleGroups.map((matchingFilter) => (

--- a/src/components/ui/filters/filter-control.tsx
+++ b/src/components/ui/filters/filter-control.tsx
@@ -17,7 +17,7 @@ export const FilterControl = memo(function FilterControl({ config, value, hasPen
         <TextRange
           title={config.label}
           hasPending={hasPending}
-          // description={config.description}
+          description={config.description}
           min={config.options[0]}
           max={config.options[1]}
           value={value as number[]}
@@ -30,7 +30,6 @@ export const FilterControl = memo(function FilterControl({ config, value, hasPen
         <CheckboxGroup
           title={config.label}
           label={config.label}
-          // description={config.description}
           items={config.options}
           value={value as string[]}
           onChange={onChange}
@@ -42,7 +41,6 @@ export const FilterControl = memo(function FilterControl({ config, value, hasPen
       return (
         <Combobox
           title={config.label}
-          // description={config.description}
           items={items}
           value={value as (string[] | undefined)}
           onChange={onChange}

--- a/src/components/ui/filters/text-range.tsx
+++ b/src/components/ui/filters/text-range.tsx
@@ -3,9 +3,11 @@ import { Box, Stack, Input, Flex, Slider } from '@chakra-ui/react';
 import { type SliderValueChangeDetails } from '@chakra-ui/react';
 import { formatNumber } from '@/utils/number';
 import { FilterLabel } from './filter-label';
+import { InfoTip } from '@/components/chakra/toggle-tip';
 
 interface TextRangeProps {
   title: string;
+  description?: string;
   min: number;
   max: number;
   value: number[];
@@ -16,6 +18,7 @@ interface TextRangeProps {
 
 export const TextRange = ({
   title,
+  description,
   min,
   max,
   value,
@@ -118,7 +121,12 @@ export const TextRange = ({
 
   return (
     <Stack gap={2} width="full">
-      <FilterLabel title={title} hasPending={hasPending} />
+      <Flex align="center" gap={1}>
+        <FilterLabel title={title} hasPending={hasPending} />
+        {description && title !== description && (
+          <InfoTip content={description} />
+        )}
+      </Flex>
 
       <Box width="full">
         <Slider.Root


### PR DESCRIPTION
This PR:
- Adds tooltips/info-tip to show filter descriptions.
- Replaces the filter collapsible group use of the <Collapsible> with the <Accordion> component from Chakra (a bit more semantic IMO, and gives some more contextually appropriate parent-level styling and controls off the shelf)
<img width="368" height="522" alt="image" src="https://github.com/user-attachments/assets/a39806f2-7157-4aa2-af8b-4e72a2b57cac" />

We are getting the descriptions from the backend, but hadn't yet rendered them. 

Because the admin area/combobox/checkbox filter labels are all wrapped in the collapsible trigger, a hover tooltip is used to avoid interaction with the dropdown. The range filters use a toggle tip (click to show info). If the inconsistency is jarring, I suggest we make all a hover tooltip - or refactor the accordion filters' descriptions to not trigger the accordion (I attempted but wasn't able to do this).