### PR TITLE
Position contextual layers above main layer

### DIFF
--- a/src/components/map/contextual-layer.tsx
+++ b/src/components/map/contextual-layer.tsx
@@ -2,21 +2,17 @@ import { Source, Layer as MapLayer } from 'react-map-gl/maplibre';
 import { useContextualLayers } from "@/utils/context/contextual-layers";
 import { deriveSource, deriveLayerStyles } from "@/utils/data-transformation";
 
-interface ContextualLayerProps {
-  mainId: string;
-}
-
-export const ContextualLayer = ({ mainId }:ContextualLayerProps) => {
-    const { layers, activeLayers } = useContextualLayers();
-    const contextualLayers = layers.filter(l => activeLayers.includes(l.id));
+export const ContextualLayer = () => {
+  const { layers, activeLayers } = useContextualLayers();
+  const contextualLayers = layers.filter(l => activeLayers.includes(l.id));
   return <>
     {contextualLayers.map(layer => {
     const source = deriveSource(layer.id, layer.filePath);
     const { circleLayer, lineLayer, polygonLayer } = deriveLayerStyles(layer.id, layer.color!);
     return <Source key={layer.id} {...source} >
-      <MapLayer {...circleLayer} beforeId={mainId} />
-      <MapLayer {...lineLayer} beforeId={mainId} />
-      <MapLayer {...polygonLayer} beforeId={mainId} />
+      <MapLayer {...circleLayer} />
+      <MapLayer {...lineLayer} />
+      <MapLayer {...polygonLayer} />
     </Source>;
   })}
   </>;

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -101,13 +101,13 @@ const MainMap = ({ main }: MainMapProps) => {
         transformRequest={transformRequest}
         interactiveLayerIds={zoom > 9 ? [main.id] : []}
       >
-        <ContextualLayer mainId={main.id} />
         <MainLayer
           scenario={scenario}
           main={main}
           mapFilter={mapFilter}
           clusterId={selected}
         />
+        <ContextualLayer />
         <ScaleControl position="bottom-left" />
         <NavigationControl showCompass={false} position="bottom-left" />
         <CenterMapControl />


### PR DESCRIPTION
Positions contextual layers above main layer by dropping `beforeId` and moving MainLayer below ContextualLayers on the map component

Before | After
-- | --
<img width="1512" height="872" alt="image" src="https://github.com/user-attachments/assets/c7a38f78-b710-432c-9275-ab3dc8f7722d" /> | <img width="1512" height="872" alt="image" src="https://github.com/user-attachments/assets/dd9cc30d-9c2b-4b73-8467-f96d7e947bac" />
