### PR TITLE
Make admin column data transformation more permissive

### DIFF
--- a/src/utils/data-transformation.ts
+++ b/src/utils/data-transformation.ts
@@ -4,7 +4,28 @@ import { Filter, FilterType, ModelMetadata, ModelGroupMetadata, Field, MapItemUn
 import { api, MEDIA_URL_PREFIX, DEFAULT_COL } from '@/utils/api';
 import { sortFilterOptions } from '@/config/filters';
 import mapConfig from '@/config/map.json';
-const ADMIN_COLUMNS = ['Admin_1', 'Admin_2', 'Admin_3', 'Admin_4', 'Region', 'Province', 'District', 'Posto', 'Postos', 'Localidade'];
+const ADMIN_COLUMNS = [
+  "Admin_1",
+  "Admin_2",
+  "Admin_3",
+  "Admin_4",
+  "Region",
+  "Regions",
+  "Região",
+  "Regiões",
+  "Province",
+  "Provinces",
+  "Província",
+  "Províncias",
+  "District",
+  "Districts",
+  "Distrito",
+  "Distritos",
+  "Posto",
+  "Postos",
+  "Localidade",
+  "Localidades",
+];
 
 // ----- API Response Types -----
 export interface ApiFilterField {


### PR DESCRIPTION
We'll better document the requirements on admin column titling to enable the grouping of admin area dropdowns, but it may also be worth making the hard-coded value mapping more flexible in this case. This PR enables the correct admin area dropdowns for the mini-grid and PUE models by including the terms "Province", "Region" and "Postos" in the list. (Added other admin specifications as well just to be fully permissive)

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/8d6903dd-1a9b-4f1e-9eb3-09a6b98d49f4" />


We could be even more flexible by including Portuguese translations and more plurals, if we wanted, like the following:

```
const ADMIN_COLUMNS = [
  "Admin_1",
  "Admin_2",
  "Admin_3",
  "Admin_4",
  "Region",
  "Regions",
  "Região",
  "Regiões",
  "Province",
  "Provinces",
  "Província",
  "Províncias",
  "District",
  "Districts",
  "Distrito",
  "Distritos",
  "Posto",
  "Postos",
  "Localidade",
  "Localidades",
];
```