### PR TITLE
Revert description as row label

### DIFF
--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -100,7 +100,7 @@ function ChartValueRows({ row }: { row: ChartRow }) {
         <Table.Cell px={2} py={2} colSpan={2} fontWeight="bold">
           <Box display="flex" alignItems="center" gap={1}>
             <Text textStyle="tableAttr">
-              {row.description || row.label}
+              {row.label}
               <Text as="span" fontWeight="normal">
                 {" "}{row.unit && `(${row.unit})`}
               </Text>
@@ -161,15 +161,17 @@ function GroupRowView({ row }: { row: GroupRow }) {
       <Table.Row key={row.label + '-group-row'} bg="gray.200">
         <Table.Cell px={2} py={2} colSpan={2} fontWeight="bold">
           <Box display="flex" alignItems="center" gap={1}>
-            {/* group type should have description as label */}
             <Text textStyle="tableAttr">
               {" "}
-              {row.description || row.label}
+              {row.label}
               <Text as="span" fontWeight="normal">
                 {" "}
                 {row.unit && `(${row.unit})`}
               </Text>
             </Text>
+            {row.description && row.label !== row.description && (
+              <InfoTip content={row.description} />
+            )}
           </Box>
         </Table.Cell>
       </Table.Row>
@@ -199,12 +201,15 @@ function NestedGroupRowView({ row }: { row: NestedGroupRow }) {
         <Table.Cell px={2} py={2} colSpan={2} fontWeight="bold">
           <Box display="flex" alignItems="center" gap={1}>
             <Text textStyle="tableAttr">
-              {row.description || row.label}
+              {row.label}
               <Text as="span" fontWeight="normal">
                 {" "}
                 {row.unit && `(${row.unit})`}
               </Text>
             </Text>
+            {row.description && row.label !== row.description && (
+              <InfoTip content={row.description} />
+            )}
           </Box>
         </Table.Cell>
       </Table.Row>


### PR DESCRIPTION
https://github.com/developmentseed/moz-proenergia-web/commit/838fcb564448f3054e445460cf8d74228fe0b4d0 introduced "description as row label" for grouped rows, which yields incorrect results. This PR reverts this label choice.

Before | After
-- | --
<img width="351" height="383" alt="image" src="https://github.com/user-attachments/assets/ec8a7592-24a0-4f8a-a3ea-c8fe9511111d" /> | <img width="351" height="438" alt="image" src="https://github.com/user-attachments/assets/3cbdb6f7-3526-4f11-b83d-c83944aab53e" />
