### PR TITLE
Update/chart position styles

### DIFF
--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -108,7 +108,7 @@ function MethodTotalRow({ item }: { item?: SummaryItem }) {
   return (
     <Table.Row bg="panelBg">
       <Table.Cell {...tableCellStyleProps}>
-        <Text textStyle="tableAttr" fontWeight="semibold">{item.label}</Text>
+        <Text textStyle="tableAttr"><Text as="span" fontWeight="semibold">Total</Text> ({item.label})</Text>
       </Table.Cell>
       <Table.Cell {...tableCellStyleProps}>
         <Text textStyle="tableValue" textAlign="right" fontFamily="mono" fontWeight="semibold">


### PR DESCRIPTION
This PT:
- pushes any row with a chart above other rows in the summary table (within categories), and 
- Positions row labels for the combined chart + values table above the chart

<img width="1512" height="1239" alt="image" src="https://github.com/user-attachments/assets/82ff1ec5-0ea2-4271-b8ec-d5487668d3e3" />

Noting - there's something strange in this branch with chart color mapping... hopefully this is not due to code changes?