### PR TITLE
Use colorCoding directly instead of valdating through summary endpoint

### DIFF
--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -23,10 +23,8 @@ import {
   transformVectorsToLayers,
   transformFilterField,
   transformMainOptions,
-  transformOptions
 } from "@/utils/data-transformation";
 import { type ModelMetadata } from "@/app/types";
-import { DEFAULT_COL } from "@/utils/api";
 import MainPanel from "./main-panel";
 import { Tooltip } from "./tooltip";
 
@@ -57,12 +55,7 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
   const defaultScenarioId = modelCore?.scenarios[0]?.id;
 
   // Filter options (single batch fetch, cached per scenario)
-  const columns = (modelCore?.filterFields ?? []).map((f) => f.column);
-  const mainCol = modelCore?.main.column;
-  if (mainCol && mainCol !== DEFAULT_COL && !columns.includes(mainCol)) {
-    columns.push(mainCol);
-  }
-  const filterColumns = columns;
+  const filterColumns = (modelCore?.filterFields ?? []).map((f) => f.column);
 
   const { data: allFilterOptions } = useQuery({
     queryKey: ["filterOptions", modelCore?.id, filterColumns],
@@ -78,11 +71,7 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
       transformFilterField(field, allFilterOptions[field.column] ?? null),
     );
 
-    // allFilterOptions should have model core's main at this point.
-    const rawMainOptions = transformOptions(allFilterOptions[modelCore.main.column] ?? null);
-
     const resolvedMainOptions = transformMainOptions(
-      rawMainOptions,
       modelCore.colorCoding,
     );
 

--- a/src/utils/data-transformation.ts
+++ b/src/utils/data-transformation.ts
@@ -359,32 +359,27 @@ export function transformFilterField(
 
 // Transform main options using color_coding from backend
 export function transformMainOptions(
-  rawOptions: MapItemUnit[] | null,
   colorCoding: ColorCoding[]
 ): MapItemUnit[] {
-
-  if (!Array.isArray(rawOptions)) return [];
-
   // Find default color (value: "any")
   const defaultColor = colorCoding.find(c => c.value === DEFAULT_COL)?.color;
+
+  const options = colorCoding
+    .filter(c => c.value && c.value !== DEFAULT_COL && c.color)
+    .map(c => ({
+      id: c.value,
+      label: makeLabel(c.value),
+      color: c.color,
+    }));
+
   // When options are missing (ex. no column to visualize)
-  if (rawOptions.length === 0) {
+  if (options.length === 0) {
     return [{
       id: DEFAULT_COL,
       label: DEFAULT_COL,
       color: defaultColor,
     }];
   }
-  // Build color lookup map
-  const colorLookup = new Map(
-    colorCoding
-      .filter(c => c.value && c.color)
-      .map(c => [c.value, c.color])
-  );
 
-  return rawOptions.map(opt => ({
-    id: String(opt.id),
-    label: opt.label,
-    color: colorLookup.get(String(opt.id)) ?? defaultColor,
-  }));
+  return options;
 }


### PR DESCRIPTION
Before, we checked the column defined as visualization column and fetched the options of it to validate the key values of colorCoding (and dropped the key if there is no match.) This was based on the thought that mainViz column always is a part of summary, which is not true for PUE. Changed it to use colorCoding raw values.

You can see value mismtach in social facilities (hopefully can be fixed by configuration) : https://deploy-preview-66--proenergina.netlify.app/model/social-facilities/?lng=32.51395264937696&lat=-25.977917756799982&zoom=9.437983483788711 
vs.
https://proenergina.netlify.app/model/social-facilities/?lng=32.930616678527485&lat=-25.76112328467738&zoom=7.833646970364315
