### PR TITLE
Dynamic routes for model

### DIFF
--- a/src/app/model/[slug]/page.tsx
+++ b/src/app/model/[slug]/page.tsx
@@ -10,13 +10,7 @@ import { SideNav } from '@/components/layout/side-nav';
 import {
   fetchModels,
   slugify,
-  fetchModelMetadata,
-  fetchVectors,
-  transformModelCore,
-  transformVectorsToLayers,
 } from '@/utils/data-transformation';
-import { type ModelGroupMetadata } from '@/app/types';
-
 
 export const dynamicParams = false;
 // Generate pages per model id
@@ -24,7 +18,8 @@ export async function generateStaticParams() {
   const res = await fetchModels();
   return res.map((model) => ({
     slug: slugify(model.name),
-  })).filter((m,idx) => idx < 4);
+  }));
+  //.filter((m,idx) => idx < 4);
 }
 
 export default async function ModelPage({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -58,7 +58,7 @@ export default function NotFound() {
       </Center>
     );
   }
-
+  // Finally, return explorer page if model was found
   return (
     <Flex h="calc(100vh - 3.5rem - 1px)" maxH="calc(100vh - 3.5rem - 1px)" overflow="hidden" width="100%">
       <SideNav models={models!} currentSlug={slug} />


### PR DESCRIPTION
since we are using Next.JS as static site generator, there is no good way to render the data if the model data was not there when pages were generated. This PR makes 404 page to validate model data one more time before failing to render the page. 
 
related issue: https://github.com/developmentseed/moz-proenergia-web/issues/74