### PR TITLE
Fix 61, simplify lat, lng, zoom

### DIFF
--- a/src/components/map/hooks/use-coordinates.ts
+++ b/src/components/map/hooks/use-coordinates.ts
@@ -4,7 +4,19 @@ import { useQueryStates, parseAsFloat, throttle } from 'nuqs';
 export const DEFAULT_COORDS = [-18.76303, 36.78403];
 export const DEFAULT_ZOOM = 5;
 
-export function useCoordinates() {
+interface Coordinates {
+  lat: number;
+  lng: number;
+  zoom: number;
+}
+
+interface UseCoordinatesReturn {
+  coords: Coordinates;
+  setCoords: (coords: Coordinates) => void;
+  removeCoordinates: () => void;
+}
+
+export function useCoordinates(): UseCoordinatesReturn {
   const [coords, setOriginCoords] = useQueryStates({
     lat: parseAsFloat.withDefault(DEFAULT_COORDS[0]),
     lng: parseAsFloat.withDefault(DEFAULT_COORDS[1]),
@@ -20,10 +32,10 @@ export function useCoordinates() {
       zoom: parseFloat(zoom.toFixed(5)),
     });
   };
-  const resetCoords = () => {
+  const removeCoordinates = () => {
     setOriginCoords({
       lat: null,lng: null, zoom: null
     });
   };
-  return [coords, setCoords, resetCoords] as const;
+  return { coords, setCoords, removeCoordinates };
 }

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -49,7 +49,8 @@ interface MainMapProps {
 }
 
 const MainMap = ({ main }: MainMapProps) => {
-  const [{ lat, lng, zoom }, setCoordinates] = useCoordinates();
+  const { coords, setCoords } = useCoordinates();
+  const { lat, lng, zoom } = coords;
   const { selected, setSelected, onClick } = useMouseEvent();
   const { isOpen, toggle, open } = useToggle(true);
 
@@ -103,7 +104,7 @@ const MainMap = ({ main }: MainMapProps) => {
           style={{ width: "100%", height: "100%" }}
           onClick={onClick}
           onMoveEnd={(e: ViewStateChangeEvent) => {
-          setCoordinates({
+          setCoords({
             lng: e.viewState.longitude,
             lat: e.viewState.latitude,
             zoom: e.viewState.zoom,
@@ -113,12 +114,12 @@ const MainMap = ({ main }: MainMapProps) => {
           transformRequest={transformRequest}
           interactiveLayerIds={zoom > 9 ? [main.id, main.id + '-line', main.id + '-circle'] : []}
       >
-        <MainLayer
-          scenario={scenario}
-          main={main}
-          mapFilter={mapFilter}
-          clusterId={selected}
-          opacity={mainLayerOpacity / 100}
+          <MainLayer
+            scenario={scenario}
+            main={main}
+            mapFilter={mapFilter}
+            clusterId={selected}
+            opacity={mainLayerOpacity / 100}
         />
           <ContextualLayer />
           <ScaleControl position="bottom-left" />

--- a/src/components/map/recenter-button.tsx
+++ b/src/components/map/recenter-button.tsx
@@ -14,7 +14,8 @@ import { controlZIndex } from "./control-constant";
 
 export function CenterMapControl() {
   const { current: map } = useMap();
-  const [{ lat: viewLat, lng: viewLng, zoom: viewZoom }] = useCoordinates();
+  const { coords } = useCoordinates();
+  const { lat: viewLat, lng: viewLng, zoom: viewZoom } = coords;
 
   const resetCenter = useCallback(() => {
     if (!map) return;

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -89,11 +89,14 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
       summaryFields: modelCore.summaryFields,
     };
   }, [modelCore, allFilterOptions]);
-  const [_, _1, resetCoords] = useCoordinates();
+
+  // Get rid of coordinates related query parameters when explorer is unmounted
+  const { removeCoordinates } = useCoordinates();
   useEffect(() => {
     return () => {
-      resetCoords();
+      removeCoordinates();
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   },[]);
 
   // @TODO: A very hacky way of telling users that the data doesn't have related scenarios


### PR DESCRIPTION
This PR does fix the problem but I am unclear on why only map-related parameters require explicit cleanup 🤔  as far as I can think of: Other query parameters depend on ModelData availability for their states - and they will be gone if modelData is not available (such as about page.) but queryparameters for maps are independent from modelData, needs an explicit clean up after...? 