### PR TITLE
Catch summary errors and show partial data where possible [WIP]

### DIFF
--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -127,7 +127,7 @@ const SummaryPanel = ({
     return () => clearTimeout(id);
   }, []);
 
-  const { data: summaryData, isLoading: summaryIsLoading } = useSummaryQuery({
+  const { data: summaryData, isLoading: summaryIsLoading, isError: summaryIsError } = useSummaryQuery({
     scenarioId,
     summaryFields,
     filters,
@@ -142,6 +142,7 @@ const SummaryPanel = ({
   const isLoading = showingCluster
     ? clusterIsLoading || clusterIsFetching
     : summaryIsLoading;
+  const isError = showingCluster ? clusterIsError : summaryIsError;
 
   const title = showingCluster ? `Cluster - ${clusterId}` : "Summary";
 
@@ -172,7 +173,7 @@ const SummaryPanel = ({
           <SummaryTable
             data={dataToDisplay}
             isLoading={isLoading}
-            isError={showingCluster && clusterIsError}
+            isError={isError}
             collapsible={!showingCluster}
           />
         </Box>

--- a/src/hooks/use-summary-query.ts
+++ b/src/hooks/use-summary-query.ts
@@ -127,17 +127,32 @@ export function useSummaryQuery({
     })),
   });
 
-  const allRows = queries.flatMap((q) => q.data ?? []);
-  const anyHasData = queries.some((q) => q.data != null);
+  // For failed buckets, substitute error rows for each field so partial
+  // data still renders and the user sees which fields couldn't load.
+  const allRows = queries.flatMap((q, i) => {
+    if (q.data) return q.data;
+    if (q.isError) {
+      return buckets[i].fields.map((field): SummaryRow => ({
+        type: "error" as const,
+        label: field.label,
+        key: field.columns[0],
+        category: field.category,
+      }));
+    }
+    return [];
+  });
 
-  const data: SummaryData | undefined = anyHasData
+  const isLoading = queries.some((q) => q.isLoading);
+  const isError = queries.every((q) => q.isError);
+
+  // Return undefined while loading or when everything failed (caller shows
+  // a generic error message). Otherwise include error rows for partial failures.
+  const data: SummaryData | undefined = !isLoading && !isError
     ? [...allRows].sort((a, b) => {
         if (a.type === b.type) return 0;
         return a.type === "flat" || a.type === "error" ? -1 : 1;
       })
     : undefined;
 
-  const isLoading = queries.some((q) => q.isLoading);
-
-  return { data, isLoading };
+  return { data, isLoading, isError };
 }


### PR DESCRIPTION
Ideally, we will show the summary fields that return correctly, but still show error messages on the national level summaries when unavailable. Currently, there is no error message shown when the summary request fails.

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/2127e17f-7d51-4f1e-9916-517ca17e34a5" />

Implementation from Claude; this is a work in progress and needs review to determine the right approach.