### PR TITLE
Order Summary Categories by string prefixes

### DIFF
--- a/src/components/layout/landing-models.tsx
+++ b/src/components/layout/landing-models.tsx
@@ -11,7 +11,6 @@ import {
   useQuery
 } from '@tanstack/react-query';
 import { slugify, fetchModels } from '@/utils/data-transformation';
-import { parseSortPrefix, stripSortPrefix } from '@/utils/string';
 import { SimpleGrid, Text, Box } from '@chakra-ui/react';
 import { DrawerSummaryTable } from './drawer-summary-table';
 import { LuArrowRight } from 'react-icons/lu';
@@ -28,9 +27,9 @@ export default function ModelCards() {
     <>
       <Heading size="3xl">Models</Heading>
       <SimpleGrid columns={2} py={6} gap={6} minChildWidth="md">
-        {[...(models ?? [])].sort((a, b) => parseSortPrefix(a.name) - parseSortPrefix(b.name)).map(e => (
-          <div key={e.id} onClick={() => setSelectedModel({ id: String(e.id), name: stripSortPrefix(e.name), description: e.description, slug: slugify(e.name) })} style={{ cursor: 'pointer' }}>
-            <Card title={stripSortPrefix(e.name)} description={e.description} />
+        {models?.map(e => (
+          <div key={e.id} onClick={() => setSelectedModel({ id: String(e.id), name: e.name, description: e.description, slug: slugify(e.name) })} style={{ cursor: 'pointer' }}>
+            <Card title={e.name} description={e.description} />
           </div>
         ))}
         {!models && <Center py={10}>

--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -6,7 +6,6 @@ import Image from 'next/image';
 import modelConfig from '@/config/model.json';
 import { ModelGroupMetadata } from '@/app/types';
 import { slugify } from '@/utils/data-transformation';
-import { parseSortPrefix, stripSortPrefix } from '@/utils/string';
 import { Tooltip } from '../ui/tooltip';
 
 interface SideNavProps {
@@ -29,7 +28,7 @@ export const SideNav = ({ models, currentSlug }: SideNavProps) => {
       zIndex={100}
     >
       <VStack p={2} gap={2} align="center">
-        {[...models].sort((a, b) => parseSortPrefix(a.name) - parseSortPrefix(b.name)).map((model) => {
+        {models.map((model) => {
           const modelSlug = slugify(model.name);
           const isActive = modelSlug === currentSlug;
           const iconPath = getIconPath(model.id);
@@ -40,7 +39,7 @@ export const SideNav = ({ models, currentSlug }: SideNavProps) => {
               href={`/model/${modelSlug}`}
               style={{ textDecoration: 'none' }}
             >
-              <Tooltip content={stripSortPrefix(model.name)}>
+              <Tooltip content={model.name}>
                 <Box
                   display="flex"
                   alignItems="center"
@@ -58,12 +57,12 @@ export const SideNav = ({ models, currentSlug }: SideNavProps) => {
                   {iconPath ? (
                     <Image
                       src={iconPath}
-                      alt={stripSortPrefix(model.name)}
+                      alt={model.name}
                       width={20}
                       height={20}
                     />
                   ) : (
-                    stripSortPrefix(model.name)
+                    model.name
                   )}
                 </Box>
               </Tooltip>

--- a/src/utils/data-transformation.ts
+++ b/src/utils/data-transformation.ts
@@ -2,7 +2,6 @@ import { LayerProps } from "react-map-gl/maplibre";
 import { interpolateWarm } from 'd3-scale-chromatic';
 import { Filter, FilterType, ModelMetadata, ModelGroupMetadata, Field, MapItemUnit, Scenario, Layer, Main } from '@/app/types';
 import { api, MEDIA_URL_PREFIX, DEFAULT_COL } from '@/utils/api';
-import { parseSortPrefix, stripSortPrefix } from '@/utils/string';
 import { sortFilterOptions } from '@/config/filters';
 import mapConfig from '@/config/map.json';
 const ADMIN_COLUMNS = [
@@ -290,10 +289,9 @@ export function transformModelCore(apiModel: ApiModelResponse): Omit<ModelMetada
     // @TODO: Filtering LCOE model until performance improvement
     // .filter(s => s.id !== 1)
     .filter(s => s.model_file !== null)
-    .sort((a, b) => parseSortPrefix(a.name) - parseSortPrefix(b.name))
     .map(s => ({
       id: String(s.id),
-      label: stripSortPrefix(s.name),
+      label: s.name,
       source: deriveSource(String(s.id), s.model_file!),
       layer: {
         id: `${s.id}-main`,
@@ -319,7 +317,7 @@ export function transformModelCore(apiModel: ApiModelResponse): Omit<ModelMetada
 
   return {
     id: modelId,
-    title: stripSortPrefix(apiModel.name),
+    title: apiModel.name,
     scenarios,
     main,
     popupFields: apiModel.popup_fields.map(f => ({
@@ -335,13 +333,11 @@ export function transformModelCore(apiModel: ApiModelResponse): Omit<ModelMetada
 
 // Transform vectors to layers
 export function transformVectorsToLayers(apiVectors: ApiVectorResult[]): Layer[] {
-  return [...apiVectors]
-    .sort((a, b) => parseSortPrefix(a.name) - parseSortPrefix(b.name))
-    .map(v => {
+  return apiVectors.map(v => {
     const sourceId = String(v.id) + 'vector-source';
     return {
       id: sourceId,
-      label: stripSortPrefix(v.name),
+      label: v.name,
       description: v.description,
       filePath: v.raw_file,
       color: v.color,


### PR DESCRIPTION
Permits the ordering of ~data models, scenarios, vector datasets, and~ summary panel categories when numeric prefixes are added to the string value `name` of these objects. After ordering, strips the numeric prefix from the label for display.

When numeric prefixes are not included, these items are then rendered according to the API order.
Closes #85 

EDIT: Removed the data model and scenario ordering, as this is now available as a field on the API response.