### PR TITLE
Summary table skeleton loader

### DIFF
--- a/src/components/chakra/summary-table-skeleton.tsx
+++ b/src/components/chakra/summary-table-skeleton.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  Box,
+  Flex,
+  Spinner,
+  Skeleton,
+  SkeletonCircle,
+  Separator,
+} from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+const STAGE_DELAYS = [2400, 3800]; // ms after mount to advance each stage
+
+const loadingMessages = [
+  "explorer.loadingSummary",
+  "explorer.loadingSummaryStage1",
+  "explorer.loadingSummaryStage2",
+];
+
+export const SummaryTableSkeleton = () => {
+  const { t } = useTranslation();
+  const [stage, setStage] = useState(0);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    setStage(0);
+    timersRef.current = STAGE_DELAYS.map((delay, i) =>
+      setTimeout(() => setStage(i + 1), delay),
+    );
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+    };
+  }, []);
+
+  return (
+    <Box display="flex" flexDir="column" py={4} gap={4}>
+      <Flex fontSize="sm" color="fg.muted" align="center" gap={2} animation="pulse 1.5s infinite ease-in-out">
+        <Spinner size="xs" />
+        <Box
+          key={stage}
+          animation="fadeSlideIn 1s ease both"
+        >
+          {t(loadingMessages[Math.min(stage, loadingMessages.length - 1)])}
+        </Box>
+      </Flex>
+
+      {stage >= 1 && (
+        <Box animation="fadeSlideIn 1s ease both" display="flex" flexDir="column" gap={4}>
+          <Skeleton width="60%" height="16px" borderRadius="lg" variant="shine" />
+          <SkeletonCircle
+            size="44"
+            mx="auto"
+            pos="relative"
+            variant="shine"
+            _after={{
+              content: "' '",
+              position: "absolute",
+              top: "25%",
+              left: "25%",
+              width: "50%",
+              height: "50%",
+              rounded: "full",
+              bg: "bg",
+              visibility: "visible",
+            }}
+          />
+          <Flex direction="column" gap={2}>
+            <Flex justify="space-between">
+              <Skeleton width="20%" height="12px" variant="shine" />
+              <Skeleton width="70%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="25%" height="12px" variant="shine" />
+              <Skeleton width="60%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="22%" height="12px" variant="shine" />
+              <Skeleton width="65%" height="12px" variant="shine" />
+            </Flex>
+          </Flex>
+        </Box>
+      )}
+
+      {stage >= 2 && (
+        <Box animation="fadeSlideIn 1s ease both" display="flex" flexDir="column" gap={4}>
+          <Separator my={4} />
+          <Skeleton width="70%" height="16px" borderRadius="lg" variant="shine" />
+          <Flex gap={4} alignItems="end">
+            <Skeleton flex="1" height="40px" variant="shine" />
+            <Skeleton flex="1" height="60px" variant="shine" />
+            <Skeleton flex="1" height="45px" variant="shine" />
+            <Skeleton flex="1" height="80px" variant="shine" />
+            <Skeleton flex="1" height="120px" variant="shine" />
+          </Flex>
+          <Flex direction="column" gap={2}>
+            <Flex justify="space-between">
+              <Skeleton width="22%" height="12px" variant="shine" />
+              <Skeleton width="65%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="25%" height="12px" variant="shine" />
+              <Skeleton width="60%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="20%" height="12px" variant="shine" />
+              <Skeleton width="70%" height="12px" variant="shine" />
+            </Flex>
+          </Flex>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -4,6 +4,10 @@ import {
   Table,
   Spinner,
   Text,
+  Skeleton,
+  SkeletonCircle,
+  Flex,
+  Separator,
 } from "@chakra-ui/react";
 import { LuChevronUp } from "react-icons/lu";
 import { InfoTip } from "./toggle-tip";
@@ -92,7 +96,9 @@ function sortChartFirst(rows: SummaryRow[]): SummaryRow[] {
   });
 }
 
-function groupByCategory(rows: SummaryRow[]): { category: string | null; rows: SummaryRow[] }[] {
+function groupByCategory(
+  rows: SummaryRow[],
+): { category: string | null; rows: SummaryRow[] }[] {
   const map = new Map<string | null, SummaryRow[]>();
   for (const row of rows) {
     const cat = row.category || null;
@@ -130,9 +136,7 @@ function FlatRowView({ row }: { row: FlatRow }) {
               {row.unit && `(${row.unit})`}{" "}
             </Text>
           </Text>
-          {row.description && (
-            <InfoTip content={row.description} />
-          )}
+          {row.description && <InfoTip content={row.description} />}
         </Box>
       </Table.Cell>
       <Table.Cell {...tableCellStyleProps}>
@@ -144,12 +148,23 @@ function FlatRowView({ row }: { row: FlatRow }) {
   );
 }
 
-function MethodTotalRow({ item, hasDecimal }: { item?: SummaryItem; hasDecimal?: boolean }) {
+function MethodTotalRow({
+  item,
+  hasDecimal,
+}: {
+  item?: SummaryItem;
+  hasDecimal?: boolean;
+}) {
   if (!item) return null;
   return (
     <Table.Row bg="panelBg" css={lastRowStyleProps}>
       <Table.Cell {...tableCellStyleProps} pb={4}>
-        <Text textStyle="tableAttr"><Text as="span" fontWeight="semibold">Total</Text> ({item.label})</Text>
+        <Text textStyle="tableAttr">
+          <Text as="span" fontWeight="semibold">
+            Total
+          </Text>{" "}
+          ({item.label})
+        </Text>
       </Table.Cell>
       <Table.Cell {...tableCellStyleProps} pb={4}>
         <Text {...valueTextProps} fontWeight="semibold">
@@ -191,7 +206,8 @@ function ChartRowView({ row }: { row: ChartRow }) {
               <Text {...sectionHeaderLabelProps}>
                 {row.label}
                 <Text as="span" fontWeight="normal">
-                  {" "}{row.unit && `(${row.unit})`}
+                  {" "}
+                  {row.unit && `(${row.unit})`}
                 </Text>
               </Text>
               {row.description && row.label !== row.description && (
@@ -202,7 +218,12 @@ function ChartRowView({ row }: { row: ChartRow }) {
         </Table.Row>
         <Table.Row _last={lastRowStyleProps}>
           <Table.Cell colSpan={2} border="none">
-            <SummaryBarChart data={row.value} average={row.showBarChartAverage ? row.average : undefined} colorMap={row.colorMap} unit={row.unit} />
+            <SummaryBarChart
+              data={row.value}
+              average={row.showBarChartAverage ? row.average : undefined}
+              colorMap={row.colorMap}
+              unit={row.unit}
+            />
           </Table.Cell>
         </Table.Row>
         {row.showChartValueRows !== false && <ChartValueRows row={row} />}
@@ -218,7 +239,8 @@ function ChartRowView({ row }: { row: ChartRow }) {
               <Text {...sectionHeaderLabelProps}>
                 {row.label}
                 <Text as="span" fontWeight="normal">
-                  {" "}{row.unit && `(${row.unit})`}
+                  {" "}
+                  {row.unit && `(${row.unit})`}
                 </Text>
               </Text>
               {row.description && row.label !== row.description && (
@@ -229,7 +251,11 @@ function ChartRowView({ row }: { row: ChartRow }) {
         </Table.Row>
         <Table.Row _last={lastRowStyleProps}>
           <Table.Cell colSpan={2} border="none">
-            <SummaryDonutChart data={row.value} colorMap={row.colorMap} unit={row.unit} />
+            <SummaryDonutChart
+              data={row.value}
+              colorMap={row.colorMap}
+              unit={row.unit}
+            />
           </Table.Cell>
         </Table.Row>
         {row.showChartValueRows !== false && <ChartValueRows row={row} />}
@@ -245,7 +271,8 @@ function ChartRowView({ row }: { row: ChartRow }) {
               <Text {...sectionHeaderLabelProps}>
                 {row.label}
                 <Text as="span" fontWeight="normal">
-                  {" "}{row.unit && `(${row.unit})`}
+                  {" "}
+                  {row.unit && `(${row.unit})`}
                 </Text>
               </Text>
               {row.description && row.label !== row.description && (
@@ -256,7 +283,11 @@ function ChartRowView({ row }: { row: ChartRow }) {
         </Table.Row>
         <Table.Row _last={lastRowStyleProps}>
           <Table.Cell colSpan={2} px={2} py={2}>
-            <SummaryStackedBarChart data={row.value} colorMap={row.colorMap} unit={row.unit} />
+            <SummaryStackedBarChart
+              data={row.value}
+              colorMap={row.colorMap}
+              unit={row.unit}
+            />
           </Table.Cell>
         </Table.Row>
         {row.showChartValueRows !== false && <ChartValueRows row={row} />}
@@ -269,7 +300,7 @@ function ChartRowView({ row }: { row: ChartRow }) {
 function GroupRowView({ row }: { row: GroupRow }) {
   return (
     <>
-      <Table.Row key={row.label + '-group-row'} {...sectionHeaderRowProps}>
+      <Table.Row key={row.label + "-group-row"} {...sectionHeaderRowProps}>
         <Table.Cell {...sectionHeaderCellProps}>
           <Box {...labelBoxProps}>
             <Text {...sectionHeaderLabelProps}>
@@ -289,10 +320,7 @@ function GroupRowView({ row }: { row: GroupRow }) {
       {row.value.map((item) => (
         <Table.Row key={item.key} {...summaryRowProps}>
           <Table.Cell {...tableCellStyleProps}>
-            <Text textStyle="tableAttr">
-              {" "}
-              {item.label}
-            </Text>
+            <Text textStyle="tableAttr"> {item.label}</Text>
           </Table.Cell>
           <Table.Cell {...tableCellStyleProps}>
             <Text {...valueTextProps}>
@@ -326,17 +354,27 @@ function NestedGroupRowView({ row }: { row: NestedGroupRow }) {
         </Table.Cell>
       </Table.Row>
       {row.value.flatMap((group) => [
-        <Table.Row key={`${row.label}-${group.key}`} bg="bg" borderTopColor="border" borderTopWidth="1px" _last={lastRowStyleProps}>
-          <Table.Cell colSpan={2} fontWeight="semibold" borderBottomColor="fg.muted">
-            <Text textStyle="tableAttr" fontSize="sm">{group.label}</Text>
+        <Table.Row
+          key={`${row.label}-${group.key}`}
+          bg="bg"
+          borderTopColor="border"
+          borderTopWidth="1px"
+          _last={lastRowStyleProps}
+        >
+          <Table.Cell
+            colSpan={2}
+            fontWeight="semibold"
+            borderBottomColor="fg.muted"
+          >
+            <Text textStyle="tableAttr" fontSize="sm">
+              {group.label}
+            </Text>
           </Table.Cell>
         </Table.Row>,
         ...group.items.map((item) => (
           <Table.Row key={`${group.key}-${item.key}`} {...summaryRowProps}>
             <Table.Cell {...tableCellStyleProps}>
-              <Text textStyle="tableAttr">
-                {item.label}
-              </Text>
+              <Text textStyle="tableAttr">{item.label}</Text>
             </Table.Cell>
             <Table.Cell {...tableCellStyleProps}>
               <Text {...valueTextProps}>
@@ -358,13 +396,20 @@ function HighlightRowView({ row }: { row: HighlightRow }) {
   }));
   return (
     <>
-      <Table.Row bg="bg" borderTopColor="border" borderTopWidth="1px" h="30px" _last={lastRowStyleProps}>
+      <Table.Row
+        bg="bg"
+        borderTopColor="border"
+        borderTopWidth="1px"
+        h="30px"
+        _last={lastRowStyleProps}
+      >
         <Table.Cell {...sectionHeaderCellProps}>
           <Box {...labelBoxProps}>
             <Text {...sectionHeaderLabelProps}>
               {row.label}
               <Text as="span" fontWeight="normal">
-                {" "}{row.unit && `(${row.unit})`}
+                {" "}
+                {row.unit && `(${row.unit})`}
               </Text>
             </Text>
             {row.description && row.label !== row.description && (
@@ -384,17 +429,30 @@ function HighlightRowView({ row }: { row: HighlightRow }) {
 
 function SummaryRowView({ row }: { row: SummaryRow }) {
   switch (row.type) {
-    case "error": return <ErrorRowView row={row} />;
-    case "flat": return <FlatRowView row={row} />;
-    case "chart": return <ChartRowView row={row} />;
-    case "group": return <GroupRowView row={row} />;
-    case "nested-group": return <NestedGroupRowView row={row} />;
-    case "highlight": return <HighlightRowView row={row} />;
-    default: return null;
+    case "error":
+      return <ErrorRowView row={row} />;
+    case "flat":
+      return <FlatRowView row={row} />;
+    case "chart":
+      return <ChartRowView row={row} />;
+    case "group":
+      return <GroupRowView row={row} />;
+    case "nested-group":
+      return <NestedGroupRowView row={row} />;
+    case "highlight":
+      return <HighlightRowView row={row} />;
+    default:
+      return null;
   }
 }
 
-export const SummaryTable = ({ data, isLoading, isError, maxHeight, collapsible = true }: SummaryTableProps) => {
+export const SummaryTable = ({
+  data,
+  isLoading,
+  isError,
+  maxHeight,
+  collapsible = true,
+}: SummaryTableProps) => {
   const groups = data
     ? groupByCategory(data).sort((a, b) => {
         if (a.category === null) return -1;
@@ -405,8 +463,79 @@ export const SummaryTable = ({ data, isLoading, isError, maxHeight, collapsible 
   return (
     <Box maxHeight={maxHeight} width="100%">
       {isLoading && (
-        <Box display="flex" alignItems="center" justifyContent="center" py={8}>
-          <Spinner colorPalette="orange" color="colorPalette.600" size="xl" />
+        <Box display="flex" flexDir="column" py={4} gap={4}>
+          <Box
+            fontSize="sm"
+            color="fg.muted"
+            animation="pulse 1.75s infinite ease-in-out"
+          >
+            Loading summaries, please wait
+          </Box>
+          <Skeleton
+            width="60%"
+            height="16px"
+            borderRadius="lg"
+            variant="shine"
+          />
+          <SkeletonCircle
+            size="44"
+            mx="auto"
+            pos="relative"
+            variant="shine"
+            _after={{
+              content: "' '",
+              position: "absolute",
+              top: "25%",
+              left: "25%",
+              width: "50%",
+              height: "50%",
+              rounded: "full",
+              bg: "bg",
+              visibility: "visible",
+            }}
+          />
+          <Flex direction="column" gap={2}>
+            <Flex justify="space-between">
+              <Skeleton width="20%" height="12px" variant="shine" />
+              <Skeleton width="70%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="25%" height="12px" variant="shine" />
+              <Skeleton width="60%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="22%" height="12px" variant="shine" />
+              <Skeleton width="65%" height="12px" variant="shine" />
+            </Flex>
+          </Flex>
+          <Separator my={4} />
+          <Skeleton
+            width="70%"
+            height="16px"
+            borderRadius="lg"
+            variant="shine"
+          />
+          <Flex gap={4} alignItems="end">
+            <Skeleton flex="1" height="40px" variant="shine" />
+            <Skeleton flex="1" height="60px" variant="shine" />
+            <Skeleton flex="1" height="45px" variant="shine" />
+            <Skeleton flex="1" height="80px" variant="shine" />
+            <Skeleton flex="1" height="120px" variant="shine" />
+          </Flex>
+          <Flex direction="column" gap={2}>
+            <Flex justify="space-between">
+              <Skeleton width="22%" height="12px" variant="shine" />
+              <Skeleton width="65%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="25%" height="12px" variant="shine" />
+              <Skeleton width="60%" height="12px" variant="shine" />
+            </Flex>
+            <Flex justify="space-between">
+              <Skeleton width="20%" height="12px" variant="shine" />
+              <Skeleton width="70%" height="12px" variant="shine" />
+            </Flex>
+          </Flex>
         </Box>
       )}
 

--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -28,6 +28,7 @@ import {
   type HighlightRow,
 } from "@/app/types/summary";
 import { Highlight } from "@/components/chakra/highlight";
+import { useTranslation } from "react-i18next";
 
 const formatValue = (value: string | number, hasDecimal?: boolean) => {
   //@ts-expect-error @TODO
@@ -110,6 +111,7 @@ function groupByCategory(
 }
 
 function ErrorRowView({ row }: { row: ErrorRow }) {
+  const { t } = useTranslation();
   return (
     <Table.Row key={row.key} {...summaryRowProps}>
       <Table.Cell {...tableCellStyleProps}>
@@ -117,7 +119,7 @@ function ErrorRowView({ row }: { row: ErrorRow }) {
       </Table.Cell>
       <Table.Cell {...tableCellStyleProps}>
         <Text textStyle="tableValue" textAlign="right" color="fg.error">
-          error
+          {t('explorer.noData')}
         </Text>
       </Table.Cell>
     </Table.Row>
@@ -453,6 +455,7 @@ export const SummaryTable = ({
   maxHeight,
   collapsible = true,
 }: SummaryTableProps) => {
+  const { t } = useTranslation();
   const groups = data
     ? groupByCategory(data).sort((a, b) => {
         if (a.category === null) return -1;
@@ -469,7 +472,7 @@ export const SummaryTable = ({
             color="fg.muted"
             animation="pulse 1.75s infinite ease-in-out"
           >
-            Loading summaries, please wait
+            {t('explorer.loadingSummary')}
           </Box>
           <Skeleton
             width="60%"
@@ -542,7 +545,7 @@ export const SummaryTable = ({
       {!isLoading && isError && (
         <Box px={4} py={4}>
           <Text color="fg.error" textStyle="tableValue">
-            Failed to load data.
+            {t('explorer.noData')}
           </Text>
         </Box>
       )}

--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -1,15 +1,6 @@
-import {
-  Accordion,
-  Box,
-  Table,
-  Spinner,
-  Text,
-  Skeleton,
-  SkeletonCircle,
-  Flex,
-  Separator,
-} from "@chakra-ui/react";
+import { Accordion, Box, Table, Text, Flex } from "@chakra-ui/react";
 import { LuChevronUp } from "react-icons/lu";
+import { SummaryTableSkeleton } from "@/components/chakra/summary-table-skeleton";
 import { InfoTip } from "./toggle-tip";
 import { formatDisplayNumber } from "@/utils/number";
 import { parseSortPrefix, stripSortPrefix } from "@/utils/string";
@@ -465,82 +456,7 @@ export const SummaryTable = ({
     : [];
   return (
     <Box maxHeight={maxHeight} width="100%">
-      {isLoading && (
-        <Box display="flex" flexDir="column" py={4} gap={4}>
-          <Box
-            fontSize="sm"
-            color="fg.muted"
-            animation="pulse 1.75s infinite ease-in-out"
-          >
-            {t('explorer.loadingSummary')}
-          </Box>
-          <Skeleton
-            width="60%"
-            height="16px"
-            borderRadius="lg"
-            variant="shine"
-          />
-          <SkeletonCircle
-            size="44"
-            mx="auto"
-            pos="relative"
-            variant="shine"
-            _after={{
-              content: "' '",
-              position: "absolute",
-              top: "25%",
-              left: "25%",
-              width: "50%",
-              height: "50%",
-              rounded: "full",
-              bg: "bg",
-              visibility: "visible",
-            }}
-          />
-          <Flex direction="column" gap={2}>
-            <Flex justify="space-between">
-              <Skeleton width="20%" height="12px" variant="shine" />
-              <Skeleton width="70%" height="12px" variant="shine" />
-            </Flex>
-            <Flex justify="space-between">
-              <Skeleton width="25%" height="12px" variant="shine" />
-              <Skeleton width="60%" height="12px" variant="shine" />
-            </Flex>
-            <Flex justify="space-between">
-              <Skeleton width="22%" height="12px" variant="shine" />
-              <Skeleton width="65%" height="12px" variant="shine" />
-            </Flex>
-          </Flex>
-          <Separator my={4} />
-          <Skeleton
-            width="70%"
-            height="16px"
-            borderRadius="lg"
-            variant="shine"
-          />
-          <Flex gap={4} alignItems="end">
-            <Skeleton flex="1" height="40px" variant="shine" />
-            <Skeleton flex="1" height="60px" variant="shine" />
-            <Skeleton flex="1" height="45px" variant="shine" />
-            <Skeleton flex="1" height="80px" variant="shine" />
-            <Skeleton flex="1" height="120px" variant="shine" />
-          </Flex>
-          <Flex direction="column" gap={2}>
-            <Flex justify="space-between">
-              <Skeleton width="22%" height="12px" variant="shine" />
-              <Skeleton width="65%" height="12px" variant="shine" />
-            </Flex>
-            <Flex justify="space-between">
-              <Skeleton width="25%" height="12px" variant="shine" />
-              <Skeleton width="60%" height="12px" variant="shine" />
-            </Flex>
-            <Flex justify="space-between">
-              <Skeleton width="20%" height="12px" variant="shine" />
-              <Skeleton width="70%" height="12px" variant="shine" />
-            </Flex>
-          </Flex>
-        </Box>
-      )}
+      {isLoading && <SummaryTableSkeleton />}
 
       {!isLoading && isError && (
         <Box px={4} py={4}>

--- a/src/components/chakra/theme.ts
+++ b/src/components/chakra/theme.ts
@@ -1,4 +1,4 @@
-import { createSystem, defaultConfig, defineConfig, defineTextStyles } from "@chakra-ui/react";
+import { createSystem, defaultConfig, defineConfig, defineTextStyles, defineKeyframes } from "@chakra-ui/react";
 // Text style sets
 
 export const textStyles = defineTextStyles({
@@ -94,8 +94,16 @@ export const textStyles = defineTextStyles({
   }
 });
 
+const keyframes = defineKeyframes({
+  fadeSlideIn: {
+    from: { opacity: 0, transform: "translateY(6px)" },
+    to:   { opacity: 1, transform: "translateY(0)" },
+  },
+});
+
 export const system = createSystem(defaultConfig, {
   theme: {
+    keyframes,
     tokens: {
       fonts: {
         heading: { value: "var(--font-dm-sans)" },

--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -80,6 +80,7 @@ const RelatedModels = ({ clusterId }: RelatedModelsProps) => {
     queryKey: ["models", token],
     queryFn: ({ signal }) => fetchModels(signal, token),
   });
+  const { t } = useTranslation();
 
   const currentModelData = models?.find((m) => String(m.id) === model.id);
   const currentVectorDatasetId = currentModelData?.scenarios[0]?.vector_dataset?.id;
@@ -95,7 +96,7 @@ const RelatedModels = ({ clusterId }: RelatedModelsProps) => {
   return (
     <Box display="flex" flexDirection="column" gap={1}>
       <Text fontSize="xs" color="fg.muted">
-        View cluster in other models
+        {t('explorer.relatedClusters')}
       </Text>
       {related.map((m) => (
         <Link

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -126,7 +126,7 @@ const ExplorerInner = () => {
 
       {/* Desktop-only summary panel toggle button */}
       <Tooltip
-        content={isSummaryOpen ? "Collapse summary panel" : "Expand summary panel"}
+        content={isSummaryOpen ? t("collapsePanel") : t("expandPanel")}
       >
         <Box
           display={{ base: "none", md: "block" }}
@@ -142,7 +142,7 @@ const ExplorerInner = () => {
           transition={`right ${AnimationTime} ease`}
         >
           <IconButton
-            aria-label={isSummaryOpen ? "Collapse summary panel" : "Expand summary panel"}
+            aria-label={isSummaryOpen ? t("collapsePanel") : t("expandPanel")}
             onClick={toggleSummary}
             variant="solid"
             size="sm"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -51,14 +51,16 @@
     "pleaseWait": "Please wait",
     "reset": "Reset",
     "apply": "Apply",
-    "loadingSummary": "Loading Summary data",
+    "loadingSummary": "Loading summary data",
+    "noData": "Failed to load summary data",
     "analysis": "analysis",
     "summary": "Summary",
     "cluster": "Cluster - {{clusterId}}",
     "failedClusterData": "Failed to load cluster data.",
     "onlyBarChart": "Only Bar Chart is available.",
     "errorNotReady": "This data doesn't look like it is ready. Make sure there are scenarios related to this model.",
-    "returnToModels": "Return to models"
+    "returnToModels": "Return to models",
+    "relatedClusters": "View cluster in other models"
   },
   "downloads": {
     "title": "Downloads",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,6 +52,8 @@
     "reset": "Reset",
     "apply": "Apply",
     "loadingSummary": "Loading summary data",
+    "loadingSummaryStage1": "Processing data…",
+    "loadingSummaryStage2": "Preparing results…",
     "noData": "Failed to load summary data",
     "analysis": "analysis",
     "summary": "Summary",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -52,13 +52,15 @@
     "reset": "Redefinir",
     "apply": "Aplicar",
     "loadingSummary": "Carregando dados de resumo",
+    "noData": "Falha ao carregar dados de resumo",
     "analysis": "análise",
     "summary": "Resumo",
     "cluster": "Cluster - {{clusterId}}",
     "failedClusterData": "Falha ao carregar dados do cluster.",
     "onlyBarChart": "Apenas Gráfico de Barras está disponível.",
     "errorNotReady": "Estes dados não parecem estar prontos. Certifique-se de que existem cenários relacionados a este modelo.",
-    "returnToModels": "Voltar para modelos"
+    "returnToModels": "Voltar para modelos",
+    "relatedClusters": "Ver cluster em outros modelos"
   },
   "downloads": {
     "title": "Downloads",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -52,6 +52,8 @@
     "reset": "Redefinir",
     "apply": "Aplicar",
     "loadingSummary": "Carregando dados de resumo",
+    "loadingSummaryStage1": "Processando dados…",
+    "loadingSummaryStage2": "Preparando resultados…",
     "noData": "Falha ao carregar dados de resumo",
     "analysis": "análise",
     "summary": "Resumo",


### PR DESCRIPTION
Adds styled skeleton loader with loading message on summary table in place of current spinner

https://github.com/user-attachments/assets/3071d0d9-5e45-4753-8fa6-ac80517f3072


## Potential issues
~NB, this is also display on the change of filters. This could be helpful if the filtered summaries take a long time to load, but could get quite distracting if a user makes a change that updates quickly, and sees a flash of the skeleton loader:~

Slow filter load:

https://github.com/user-attachments/assets/b816a11a-809d-48a4-b14a-91a5a5f120e3

Fast:

https://github.com/user-attachments/assets/520e9967-16ee-425c-b892-7495cd4034e5


**Potential Solution**
~To handle the above issue, I prompted Claude to help me figure out how to show a different loader for the first load vs. if the filters have changed - it suggested and implemented the features from TanStackQuery `placeholderData` `keepPreviousData` and `isFetching`. With a combination of refs and exposing these additional props, it implemented an acceptable solution. It's not perfect; and indeed, now is a bit of the reverse issue - if a user has a slow filter load, it is not very different from the current deployed spinner, and is a little frustrating to have a big blank panel there again. I think I could probably prompt my way to a solution where the more detiled skeleton is exposed after a certain number of seconds of loading, but this feels over-engineered. I haven't pushed up the code for the different loader that states "Updating" with a spinner - happy to do so if this feels like the correct solution.~

Fast:

https://github.com/user-attachments/assets/1f296090-53ba-4967-adbf-611db266c24e

Slow:

https://github.com/user-attachments/assets/49baffbe-088a-4c8b-bf09-c74d58e44836

**EDIT:** See comment https://github.com/developmentseed/moz-proenergia-web/pull/137#issuecomment-4215986633

Closes #136 