### PR TITLE
Add react joyride tour

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "19.2.4",
     "react-i18next": "^16.5.4",
     "react-icons": "^5.5.0",
+    "react-joyride": "^3.0.2",
     "react-map-gl": "^8.1.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.2.4)
+      react-joyride:
+        specifier: ^3.0.2
+        version: 3.0.2(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-map-gl:
         specifier: ^8.1.0
         version: 8.1.0(maplibre-gl@5.17.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -392,6 +395,9 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
+
   '@fastify/otel@0.18.0':
     resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
     peerDependencies:
@@ -400,16 +406,42 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.4':
     resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
 
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@geomatico/maplibre-cog-protocol@0.8.0':
     resolution: {integrity: sha512-q5Pg7pOp/fRB/UrAUEZ4AEF/B68XwvxMg0YRk0z+UwwHfOKQThkY7u91Kusx2AwIme6QOURFK6Fvw39ooj68RQ==}
     peerDependencies:
       maplibre-gl: ^4.5.0 || ^5.0.0
+
+  '@gilbarbara/deep-equal@0.4.1':
+    resolution: {integrity: sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==}
+
+  '@gilbarbara/hooks@0.11.0':
+    resolution: {integrity: sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==}
+    peerDependencies:
+      react: 16.8 - 19
+
+  '@gilbarbara/types@0.2.2':
+    resolution: {integrity: sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3158,6 +3190,9 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-lite@2.0.0:
+    resolution: {integrity: sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -3922,11 +3957,23 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-innertext@1.1.5:
+    resolution: {integrity: sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==}
+    peerDependencies:
+      '@types/react': '>=0.0.0 <=99'
+      react: '>=0.0.0 <=99'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-joyride@3.0.2:
+    resolution: {integrity: sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==}
+    peerDependencies:
+      react: 16.8 - 19
+      react-dom: 16.8 - 19
 
   react-map-gl@8.1.0:
     resolution: {integrity: sha512-vDx/QXR3Tb+8/ap/z6gdMjJQ8ZEyaZf6+uMSPz7jhWF5VZeIsKsGfPvwHVPPwGF43Ryn+YR4bd09uEFNR5OPdg==}
@@ -4090,6 +4137,12 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  scroll@3.0.1:
+    resolution: {integrity: sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==}
+
+  scrollparent@2.1.0:
+    resolution: {integrity: sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4382,6 +4435,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5073,6 +5130,8 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@fastify/deepmerge@3.2.1': {}
+
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5087,12 +5146,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.4':
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@geomatico/maplibre-cog-protocol@0.8.0(maplibre-gl@5.17.0)':
     dependencies:
@@ -5101,6 +5177,17 @@ snapshots:
       geotiff: 2.1.3
       maplibre-gl: 5.17.0
       quick-lru: 7.3.0
+
+  '@gilbarbara/deep-equal@0.4.1': {}
+
+  '@gilbarbara/hooks@0.11.0(react@19.2.4)':
+    dependencies:
+      '@gilbarbara/deep-equal': 0.4.1
+      react: 19.2.4
+
+  '@gilbarbara/types@0.2.2':
+    dependencies:
+      type-fest: 4.41.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -8375,6 +8462,8 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-lite@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -9279,9 +9368,31 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-innertext@1.1.5(@types/react@19.2.7)(react@19.2.4):
+    dependencies:
+      '@types/react': 19.2.7
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-joyride@3.0.2(@types/react@19.2.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@fastify/deepmerge': 3.2.1
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@gilbarbara/deep-equal': 0.4.1
+      '@gilbarbara/hooks': 0.11.0(react@19.2.4)
+      '@gilbarbara/types': 0.2.2
+      is-lite: 2.0.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-innertext: 1.1.5(@types/react@19.2.7)(react@19.2.4)
+      scroll: 3.0.1
+      scrollparent: 2.1.0
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react-map-gl@8.1.0(maplibre-gl@5.17.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -9558,6 +9669,10 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
+
+  scroll@3.0.1: {}
+
+  scrollparent@2.1.0: {}
 
   semver@6.3.1: {}
 
@@ -9886,6 +10001,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.7.1: {}
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { WEBSITE_DESC, WEBSITE_TITLE } from "@/config/website";
 import Header from "@/components/layout/header/";
 import { AuthProvider } from "@/utils/context/auth";
+import { TourProvider } from "@/context/tour";
 import { I18nProvider } from "@/i18n/provider";
 import { DM_Sans, DM_Mono } from "next/font/google";
 import "./globals.css";
@@ -47,10 +48,12 @@ export default function RootLayout({
             <NuqsAdapter>
               <Provider>
                 <AuthProvider>
-                  <Header />
-                  <Box as="main" bg="bg">
-                    {children}
-                  </Box>
+                  <TourProvider>
+                    <Header />
+                    <Box as="main" bg="bg">
+                      {children}
+                    </Box>
+                  </TourProvider>
                 </AuthProvider>
               </Provider>
             </NuqsAdapter>

--- a/src/app/types/ui.ts
+++ b/src/app/types/ui.ts
@@ -4,4 +4,5 @@ export type TabItem = {
   id: string;
   label: JSX.Element;
   Component: FunctionComponent;
+  triggerProps?: Record<string, string>;
 }

--- a/src/components/chakra/tab.tsx
+++ b/src/components/chakra/tab.tsx
@@ -30,7 +30,7 @@ const Tab = ({ items, value, onValueChange, onTabClick }: TabProps) => {
     >
       <Tabs.List>
         {items.map((item) => (
-          <Tabs.Trigger key={item.id} value={item.id} colorPalette="orange" onClick={onTabClick}>
+          <Tabs.Trigger key={item.id} value={item.id} colorPalette="orange" onClick={onTabClick} {...item.triggerProps}>
             {item.label}
           </Tabs.Trigger>
         ))}

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -44,7 +44,7 @@ export const Header = ({
     return pathname === href + "/";
   };
 
-  const showTourHelpButton = pathname.startsWith("/model") || pathname === "/models/";
+  const showTourHelpButton = pathname.startsWith("/model")
 
   return (
     <Box

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { LuMenu } from "react-icons/lu";
 import DropdownMenu, { DropdownMenuItems } from "./dropdown-menu";
 import { LanguageSwitcher } from "./language-switcher";
+import { TourHelpButton } from "@/components/tour/explorer-tour";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/utils/context/auth";
 import { zIndex } from "@/components/ui/constant";
@@ -42,6 +43,8 @@ export const Header = ({
       return true;
     return pathname === href + "/";
   };
+
+  const showTourHelpButton = pathname.startsWith("/model") || pathname === "/models/";
 
   return (
     <Box
@@ -108,6 +111,7 @@ export const Header = ({
             })}
             <Separator orientation="vertical" height="4" />
             <LanguageSwitcher />
+            {showTourHelpButton && <TourHelpButton />}
             <Separator orientation="vertical" height="4" />
           </HStack>
 

--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -33,6 +33,7 @@ export const SideNav = ({ models, currentSlug }: SideNavProps) => {
 
   return (
     <Box
+      data-tour="side-nav"
       display={{ base: 'none', md: 'flex' }}
       flexDirection="column"
       height="full"

--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -286,6 +286,7 @@ const SummaryPanel = ({
 
       {/* Desktop: right panel with width animation */}
       <Box
+        data-tour="summary-panel"
         display={{ base: "none", md: "flex" }}
         {...mapControlCommonStyleProps}
         position="relative"

--- a/src/components/tour/explorer-tour.tsx
+++ b/src/components/tour/explorer-tour.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useCallback } from "react";
+import { Box, Flex, Checkbox, Text, Button, IconButton } from "@chakra-ui/react";
+import {
+  useTour,
+  TOUR_OPT_OUT_KEY,
+  TOUR_VISITS_KEY,
+  TOUR_SESSION_KEY,
+  MAX_AUTO_SHOW_VISITS,
+} from "@/context/tour";
+import { useTranslation } from "react-i18next";
+import type { EventData, Step } from "react-joyride";
+import { LuCircleHelp, LuMessageCircleQuestion } from "react-icons/lu";
+
+// Dynamically imported to avoid SSR issues. react-joyride v3 uses named export.
+const Joyride = dynamic(
+  () => import("react-joyride").then((mod) => ({ default: mod.Joyride })),
+  { ssr: false },
+);
+
+// Separated so the checkbox always reads fresh context state
+const WelcomeStepContent = () => {
+  const { dontShowAgain, setDontShowAgain } = useTour();
+  const { t } = useTranslation();
+  return (
+    <Box>
+      <Text mb={4}>{t("tour.step1.content")}</Text>
+      <Checkbox.Root
+        checked={dontShowAgain}
+        onCheckedChange={({ checked }) => setDontShowAgain(!!checked)}
+        size="sm"
+      >
+        <Checkbox.HiddenInput />
+        <Checkbox.Control />
+        <Checkbox.Label color="fg.muted">{t("tour.dontShowAgain")}</Checkbox.Label>
+      </Checkbox.Root>
+    </Box>
+  );
+};
+
+export function ExplorerTour() {
+  const { t } = useTranslation();
+  const {
+    isRunning,
+    stepIndex,
+    setStepIndex,
+    startTour,
+    stopTour,
+    callAction,
+  } = useTour();
+
+  // Auto-start: count one visit per browser session, show for first N sessions
+  useEffect(() => {
+    const optOut = localStorage.getItem(TOUR_OPT_OUT_KEY) === "true";
+    if (optOut) return;
+
+    const alreadyCounted = sessionStorage.getItem(TOUR_SESSION_KEY) === "true";
+    if (!alreadyCounted) {
+      sessionStorage.setItem(TOUR_SESSION_KEY, "true");
+      const visits = parseInt(localStorage.getItem(TOUR_VISITS_KEY) ?? "0", 10);
+      const newVisits = visits + 1;
+      localStorage.setItem(TOUR_VISITS_KEY, String(newVisits));
+
+      if (newVisits <= MAX_AUTO_SHOW_VISITS) {
+        const id = setTimeout(() => startTour(false), 900);
+        return () => clearTimeout(id);
+      }
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const steps: Step[] = [
+    {
+      target: "body",
+      placement: "center",
+      skipBeacon: true,
+      title: t("tour.step1.title"),
+      content: <WelcomeStepContent />,
+    },
+    {
+      target: '[data-tour="side-nav"]',
+      placement: "right",
+      skipBeacon: true,
+      title: t("tour.step2.title"),
+      content: t("tour.step2.content"),
+    },
+    {
+      target: '[data-tour="scenario-select"]',
+      placement: "right",
+      skipBeacon: true,
+      title: t("tour.step3.title"),
+      content: t("tour.step3.content"),
+    },
+    {
+      target: '[data-tour="filters-panel"]',
+      placement: "right",
+      skipBeacon: true,
+      title: t("tour.step4.title"),
+      content: t("tour.step4.content"),
+    },
+    {
+      target: '[data-tour="map"]',
+      placement: "left",
+      skipBeacon: true,
+      title: t("tour.step5.title"),
+      content: t("tour.step5.content"),
+    },
+    {
+      target: '[data-tour="summary-panel"]',
+      placement: "left",
+      skipBeacon: true,
+      title: t("tour.step6.title"),
+      content: t("tour.step6.content"),
+    },
+    {
+      target: '[data-tour="summary-panel"]',
+      placement: "left",
+      skipBeacon: true,
+      title: t("tour.step7.title"),
+      content: t("tour.step7.content"),
+    },
+    {
+      target: '[data-tour="layers-tab"]',
+      placement: "right",
+      skipBeacon: true,
+      title: t("tour.step8.title"),
+      content: t("tour.step8.content"),
+    },
+  ];
+
+  const handleEvent = useCallback(
+    (data: EventData) => {
+      const { action, index, status, type } = data;
+
+      if (type === "step:after" || type === "error:target_not_found") {
+        const isNext = action === "next";
+        const isPrev = action === "prev";
+
+        if (isNext) {
+          if (index === 3) {
+            // Leaving filters step — programmatically apply a demo filter
+            callAction("applyDemoFilter");
+          }
+          if (index === 5) {
+            // Leaving national summary step — select a demo cluster
+            callAction("selectDemoCluster");
+          }
+        }
+
+        setStepIndex(index + (isPrev ? -1 : 1));
+      }
+
+      if (status === "finished" || status === "skipped") {
+        stopTour();
+      }
+    },
+    [callAction, setStepIndex, stopTour],
+  );
+
+  return (
+    <Joyride
+      steps={steps}
+      run={isRunning}
+      stepIndex={stepIndex}
+      onEvent={handleEvent}
+      continuous
+      options={{
+        buttons: ["back", "primary", "skip"],
+        showProgress: true,
+        skipBeacon: true,
+        primaryColor: "#CC5500",
+        zIndex: 9999,
+        overlayColor: "rgba(0,0,0,0.4)",
+      }}
+      locale={{
+        back: t("tour.back"),
+        close: t("tour.close"),
+        last: t("tour.finish"),
+        next: t("tour.next"),
+        skip: t("tour.skip"),
+      }}
+      styles={{
+        tooltip: {
+          borderRadius: "8px",
+          padding: "16px 20px",
+          maxWidth: "360px",
+        },
+        tooltipTitle: {
+          fontSize: "1rem",
+          fontWeight: 600,
+          marginBottom: "8px",
+          textAlign: "left",
+        },
+        tooltipContent: {
+          padding: "0 0 8px",
+          fontSize: "0.875rem",
+          lineHeight: 1.25,
+          textAlign: "left",
+        },
+        buttonPrimary: {
+          backgroundColor: "#CC5500",
+          borderRadius: "6px",
+          fontSize: "0.875rem",
+          padding: "8px 12px",
+        },
+        buttonBack: {
+          color: "#CC5500",
+          fontSize: "0.875rem",
+          padding: "8px 12px",
+        },
+        buttonSkip: {
+          color: "#888",
+          fontSize: "0.875rem",
+        },
+        buttonClose: {
+          top: "12px",
+          right: "12px",
+        },
+      }}
+    />
+  );
+}
+
+export function TourHelpButton() {
+  const { startTour } = useTour();
+  const { t } = useTranslation();
+
+  return (
+    <IconButton
+      aria-label={t("tour.openTour")}
+      onClick={() => startTour(true)}
+      variant="plain"
+      colorPalette="orange"
+      color="orange.contrast"
+      cursor="pointer"
+      _hover={{ opacity: 1 }}
+      transition="opacity 0.15s"
+    >
+      <LuCircleHelp size={18} />
+    </IconButton>
+  );
+}

--- a/src/components/tour/explorer-tour.tsx
+++ b/src/components/tour/explorer-tour.tsx
@@ -121,7 +121,7 @@ export function ExplorerTour() {
       content: t("tour.step7.content"),
     },
     {
-      target: '[data-tour="layers-tab"]',
+      target: '[data-tour="filters-panel"]',
       placement: "right",
       skipBeacon: true,
       title: t("tour.step8.title"),
@@ -143,8 +143,10 @@ export function ExplorerTour() {
             callAction("selectDemoCluster");
           }
           if (index === 6) {
-            // Switch to layers tab so the panel content is visible
+            // Switch to layers tab, wait for DOM update, then advance
             callAction("switchToLayers");
+            setTimeout(() => setStepIndex(7), 200);
+            return;
           }
         }
         if (isPrev && index === 7) {

--- a/src/components/tour/explorer-tour.tsx
+++ b/src/components/tour/explorer-tour.tsx
@@ -138,14 +138,18 @@ export function ExplorerTour() {
         const isPrev = action === "prev";
 
         if (isNext) {
-          if (index === 3) {
-            // Leaving filters step — programmatically apply a demo filter
-            callAction("applyDemoFilter");
-          }
           if (index === 5) {
             // Leaving national summary step — select a demo cluster
             callAction("selectDemoCluster");
           }
+          if (index === 6) {
+            // Switch to layers tab so the panel content is visible
+            callAction("switchToLayers");
+          }
+        }
+        if (isPrev && index === 7) {
+          // Going back from layers step — restore controls tab
+          callAction("switchToControls");
         }
 
         setStepIndex(index + (isPrev ? -1 : 1));

--- a/src/components/ui/control.tsx
+++ b/src/components/ui/control.tsx
@@ -264,7 +264,6 @@ const Control = ({
         </>
       ),
       Component: LayersPanel,
-      triggerProps: { "data-tour": "layers-tab" },
     },
   ];
   return (

--- a/src/components/ui/control.tsx
+++ b/src/components/ui/control.tsx
@@ -264,6 +264,7 @@ const Control = ({
         </>
       ),
       Component: LayersPanel,
+      triggerProps: { "data-tour": "layers-tab" },
     },
   ];
   return (

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -38,7 +38,8 @@ import { useTour } from "@/context/tour";
 
 const ExplorerInner = () => {
   const { model, scenarioId } = useModel();
-  const { updatedFilters, setPendingFilters, applyPendingChanges } = useFilters();
+  const { updatedFilters } = useFilters();
+  const [activeControlTab, setActiveControlTab] = useState<string>("controls");
   const { selected, onClick, setSelected } = useMouseEvent();
   const { t } = useTranslation();
 
@@ -70,23 +71,18 @@ const ExplorerInner = () => {
   const { registerAction } = useTour();
 
   useEffect(() => {
-    // Apply first numeric filter to half its max value as a demo
-    registerAction("applyDemoFilter", () => {
-      const numericFilter = model.filters.find((f) => f.type === "numeric");
-      if (numericFilter) {
-        const opts = numericFilter.options as [number, number];
-        const mid = Math.round(opts[0] + (opts[1] - opts[0]) / 2);
-        setPendingFilters({ [numericFilter.id]: [opts[0], mid] });
-        // Small delay so the user sees the filter update before apply fires
-        setTimeout(() => applyPendingChanges(), 300);
-      }
+    registerAction("selectDemoCluster", () => {
+      setSelected("20213");
     });
 
-    registerAction("selectDemoCluster", () => {
-      const demoCluster = "20819";
-      setSelected(demoCluster);
+    registerAction("switchToLayers", () => {
+      setActiveControlTab("layers");
     });
-  }, [registerAction, model.filters, setPendingFilters, applyPendingChanges, setSelected]);
+
+    registerAction("switchToControls", () => {
+      setActiveControlTab("controls");
+    });
+  }, [registerAction, setSelected, setActiveControlTab]);
 
   return (
     <Box
@@ -99,6 +95,8 @@ const ExplorerInner = () => {
       <MainPanel
         isOpen={isControlsOpen}
         onToggle={() => setIsControlsOpen((prev) => !prev)}
+        activeTab={activeControlTab}
+        onTabChange={setActiveControlTab}
       />
 
       {/* Desktop-only toggle button */}

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -70,9 +70,19 @@ const ExplorerInner = () => {
   // Tour: register programmatic actions
   const { registerAction } = useTour();
 
+  // Known representative cluster IDs per model, used by the guided tour
+  const DEMO_CLUSTERS: Record<string, string> = {
+    "1": "20213",
+    "2": "20213",
+    "3": "20213",
+    "4": "1525",
+    "5": "364261",
+  };
+
   useEffect(() => {
     registerAction("selectDemoCluster", () => {
-      setSelected("20213");
+      const clusterId = DEMO_CLUSTERS[String(model.id)];
+      if (clusterId) setSelected(clusterId);
     });
 
     registerAction("switchToLayers", () => {
@@ -82,7 +92,7 @@ const ExplorerInner = () => {
     registerAction("switchToControls", () => {
       setActiveControlTab("controls");
     });
-  }, [registerAction, setSelected, setActiveControlTab]);
+  }, [registerAction, model.id, setSelected, setActiveControlTab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Box

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -33,10 +33,12 @@ import { useTranslation } from "react-i18next";
 import { useToggle } from "@/hooks/use-toggle";
 import { useMouseEvent } from "@/components/map/hooks/use-mouse-event";
 import { ControlPanelWidth, AnimationTime } from "./main-panel";
+import { ExplorerTour } from "@/components/tour/explorer-tour";
+import { useTour } from "@/context/tour";
 
 const ExplorerInner = () => {
   const { model, scenarioId } = useModel();
-  const { updatedFilters } = useFilters();
+  const { updatedFilters, setPendingFilters, applyPendingChanges } = useFilters();
   const { selected, onClick, setSelected } = useMouseEvent();
   const { t } = useTranslation();
 
@@ -63,6 +65,28 @@ const ExplorerInner = () => {
       openSummary();
     }
   }, [selected, openSummary]);
+
+  // Tour: register programmatic actions
+  const { registerAction } = useTour();
+
+  useEffect(() => {
+    // Apply first numeric filter to half its max value as a demo
+    registerAction("applyDemoFilter", () => {
+      const numericFilter = model.filters.find((f) => f.type === "numeric");
+      if (numericFilter) {
+        const opts = numericFilter.options as [number, number];
+        const mid = Math.round(opts[0] + (opts[1] - opts[0]) / 2);
+        setPendingFilters({ [numericFilter.id]: [opts[0], mid] });
+        // Small delay so the user sees the filter update before apply fires
+        setTimeout(() => applyPendingChanges(), 300);
+      }
+    });
+
+    registerAction("selectDemoCluster", () => {
+      const demoCluster = "20819";
+      setSelected(demoCluster);
+    });
+  }, [registerAction, model.filters, setPendingFilters, applyPendingChanges, setSelected]);
 
   return (
     <Box
@@ -115,7 +139,7 @@ const ExplorerInner = () => {
       </Tooltip>
 
       {/* Map area */}
-      <Box flex={1} height="full" minHeight={0} position="relative">
+      <Box data-tour="map" flex={1} height="full" minHeight={0} position="relative">
         <MainMap
           main={model.main}
           onClick={onClick}
@@ -175,6 +199,8 @@ const ExplorerInner = () => {
         isOpen={isSummaryOpen}
         onToggle={toggleSummary}
       />
+
+      <ExplorerTour />
     </Box>
   );
 };

--- a/src/components/ui/main-panel.tsx
+++ b/src/components/ui/main-panel.tsx
@@ -115,15 +115,19 @@ const MainPanel = ({
           <Heading as="h2" textStyle="modelTitle">
             {t(`model.${model.id}.name`, { defaultValue: model.title })}
           </Heading>
-          <Select
-            title={t('explorer.scenario')}
-            items={scenarioItems}
-            value={scenarioId}
-            onChange={onChange}
-            props={{}}
-          />
+          <Box data-tour="scenario-select">
+            <Select
+              title={t('explorer.scenario')}
+              items={scenarioItems}
+              value={scenarioId}
+              onChange={onChange}
+              props={{}}
+            />
+          </Box>
         </Box>
-        <ControlPanel />
+        <Box data-tour="filters-panel" flex="1" display="flex" flexDirection="column" overflow="hidden">
+          <ControlPanel />
+        </Box>
       </Box>
     </Box>
   );

--- a/src/components/ui/main-panel.tsx
+++ b/src/components/ui/main-panel.tsx
@@ -16,9 +16,13 @@ export const AnimationTime = "0.32s";
 const MainPanel = ({
   isOpen,
   onToggle = () => {},
+  activeTab,
+  onTabChange,
 }: {
   isOpen: boolean;
   onToggle?: () => void;
+  activeTab?: string;
+  onTabChange?: (tab: string) => void;
 }) => {
   const { model, scenarioId, setScenarioId } = useModel();
   const { t } = useTranslation();
@@ -126,7 +130,7 @@ const MainPanel = ({
           </Box>
         </Box>
         <Box data-tour="filters-panel" flex="1" display="flex" flexDirection="column" overflow="hidden">
-          <ControlPanel />
+          <ControlPanel activeTab={activeTab} onTabChange={onTabChange} />
         </Box>
       </Box>
     </Box>

--- a/src/context/tour.tsx
+++ b/src/context/tour.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
+
+export const TOUR_OPT_OUT_KEY = "proenergia_tour_opt_out";
+export const TOUR_VISITS_KEY = "proenergia_tour_visits";
+export const TOUR_SESSION_KEY = "proenergia_tour_session_counted";
+export const MAX_AUTO_SHOW_VISITS = 5;
+
+interface TourContextType {
+  isRunning: boolean;
+  stepIndex: number;
+  setStepIndex: (n: number) => void;
+  startTour: (manual?: boolean) => void;
+  stopTour: () => void;
+  isManual: boolean;
+  registerAction: (name: string, fn: (...args: unknown[]) => void) => void;
+  callAction: (name: string, ...args: unknown[]) => void;
+  dontShowAgain: boolean;
+  setDontShowAgain: (v: boolean) => void;
+}
+
+const TourContext = createContext<TourContextType | null>(null);
+
+export function TourProvider({ children }: { children: ReactNode }) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isManual, setIsManual] = useState(false);
+  const [dontShowAgain, setDontShowAgainState] = useState(false);
+  const actionsRef = useRef<Record<string, (...args: unknown[]) => void>>({});
+
+  const registerAction = useCallback(
+    (name: string, fn: (...args: unknown[]) => void) => {
+      actionsRef.current[name] = fn;
+    },
+    [],
+  );
+
+  const callAction = useCallback((name: string, ...args: unknown[]) => {
+    actionsRef.current[name]?.(...args);
+  }, []);
+
+  const setDontShowAgain = useCallback((v: boolean) => {
+    setDontShowAgainState(v);
+    if (v) localStorage.setItem(TOUR_OPT_OUT_KEY, "true");
+    else localStorage.removeItem(TOUR_OPT_OUT_KEY);
+  }, []);
+
+  const startTour = useCallback((manual = false) => {
+    setIsManual(manual);
+    setStepIndex(0);
+    setIsRunning(true);
+  }, []);
+
+  const stopTour = useCallback(() => {
+    setIsRunning(false);
+    setStepIndex(0);
+  }, []);
+
+  return (
+    <TourContext.Provider
+      value={{
+        isRunning,
+        stepIndex,
+        setStepIndex,
+        startTour,
+        stopTour,
+        isManual,
+        registerAction,
+        callAction,
+        dontShowAgain,
+        setDontShowAgain,
+      }}
+    >
+      {children}
+    </TourContext.Provider>
+  );
+}
+
+export function useTour() {
+  const ctx = useContext(TourContext);
+  if (!ctx) throw new Error("useTour must be used within TourProvider");
+  return ctx;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -102,6 +102,47 @@
     "rasterMin": "Min: {{value}}",
     "rasterMax": "Max: {{value}}"
   },
+  "tour": {
+    "back": "Back",
+    "close": "Close",
+    "finish": "Finish",
+    "next": "Next",
+    "skip": "Skip tour",
+    "openTour": "Open guided tour",
+    "dontShowAgain": "Don't show this tour automatically again",
+    "step1": {
+      "title": "Welcome to the Integrated Energy Planning Platform",
+      "content": "This platform allows you to explore energy access modelling results for Mozambique. You can visualise least-cost electrification pathways, filter by geography and attributes, and inspect summary statistics for any area."
+    },
+    "step2": {
+      "title": "Select a Model",
+      "content": "Use the sidebar icons to switch between available planning models. Each model represents a distinct analytical scenario or dataset."
+    },
+    "step3": {
+      "title": "Choose a Scenario",
+      "content": "Each model may contain multiple scenarios — for example, different investment horizons or policy assumptions. Use this dropdown to switch between them."
+    },
+    "step4": {
+      "title": "Apply Filters",
+      "content": "Use the Controls panel to filter settlements by attributes such as distance to infrastructure, population size, or administrative area. Adjust the values and press Apply to update the map and summary."
+    },
+    "step5": {
+      "title": "Explore the Map",
+      "content": "The map updates to reflect your active filters. Each point represents a settlement, coloured by the least-cost electrification technology. Click any settlement to inspect it individually."
+    },
+    "step6": {
+      "title": "National Summary",
+      "content": "The summary panel shows aggregated statistics for all settlements currently visible given your filters — including technology breakdowns, population, and projected connections."
+    },
+    "step7": {
+      "title": "Cluster Detail",
+      "content": "When you select an individual settlement, the summary panel switches to show its specific attributes — such as coordinates, population, and the recommended electrification technology."
+    },
+    "step8": {
+      "title": "Additional Layers",
+      "content": "Switch to the Layers tab to toggle contextual map layers such as administrative boundaries, grid infrastructure, or other reference datasets."
+    }
+  },
   "breadcrumbs": {
     "about": "About",
     "downloads": "Downloads"

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -102,6 +102,47 @@
     "rasterMin": "Mín: {{value}}",
     "rasterMax": "Máx: {{value}}"
   },
+  "tour": {
+    "back": "Anterior",
+    "close": "Fechar",
+    "finish": "Concluir",
+    "next": "Próximo",
+    "skip": "Pular visita",
+    "openTour": "Abrir visita guiada",
+    "dontShowAgain": "Não mostrar esta visita automaticamente novamente",
+    "step1": {
+      "title": "Bem-vindo à Plataforma Integrada de Electrificação",
+      "content": "Esta plataforma permite explorar os resultados de modelos de acesso à energia em Moçambique. Pode visualizar os caminhos de eletrificação de menor custo, filtrar por geografia e atributos, e consultar estatísticas resumidas para qualquer área."
+    },
+    "step2": {
+      "title": "Selecionar um Modelo",
+      "content": "Utilize os ícones na barra lateral para alternar entre os modelos de planeamento disponíveis. Cada modelo representa um conjunto de dados ou cenário analítico distinto."
+    },
+    "step3": {
+      "title": "Escolher um Cenário",
+      "content": "Cada modelo pode conter vários cenários — por exemplo, diferentes horizontes de investimento ou pressupostos de política. Utilize este menu para alternar entre eles."
+    },
+    "step4": {
+      "title": "Aplicar Filtros",
+      "content": "Utilize o painel de Controles para filtrar assentamentos por atributos como distância a infraestruturas, dimensão da população ou área administrativa. Ajuste os valores e pressione Aplicar para atualizar o mapa e o resumo."
+    },
+    "step5": {
+      "title": "Explorar o Mapa",
+      "content": "O mapa atualiza-se para refletir os seus filtros ativos. Cada ponto representa um assentamento, colorido pela tecnologia de eletrificação de menor custo. Clique em qualquer assentamento para o inspecionar individualmente."
+    },
+    "step6": {
+      "title": "Resumo Nacional",
+      "content": "O painel de resumo mostra estatísticas agregadas para todos os assentamentos visíveis com os seus filtros atuais — incluindo desagregação por tecnologia, população e ligações previstas."
+    },
+    "step7": {
+      "title": "Detalhe do Cluster",
+      "content": "Ao selecionar um assentamento individual, o painel de resumo passa a mostrar os seus atributos específicos — como coordenadas, população e a tecnologia de eletrificação recomendada."
+    },
+    "step8": {
+      "title": "Camadas Adicionais",
+      "content": "Mude para o separador Camadas para ativar ou desativar camadas contextuais do mapa, como limites administrativos, infraestrutura de rede ou outros conjuntos de dados de referência."
+    }
+  },
   "breadcrumbs": {
     "about": "Sobre",
     "downloads": "Downloads"


### PR DESCRIPTION
Adds react joyride tour to provide onboarding to frontend explore tool.

<img width="707" height="510" alt="image" src="https://github.com/user-attachments/assets/ccac4f91-4abd-4fa3-abcb-c4fa78063711" />

This PR was written first by mirroring from the [PEARL](https://github.com/developmentseed/pearl-frontend/blob/develop/app/assets/scripts/components/common/tour.js) and [Rezoning](https://github.com/developmentseed/rezoning-web/blob/develop/app/assets/scripts/components/common/tour.js) projects, and then having 🤖 Claude help configure the local storage and i18n functionality.

The tour: 
- is only visible and mounted on the /model explore page
- starts automatically for new visitors
- can be skipped, with a "don't show this again" checkbox
- will show the tour for five (5) visits, and then stop showing automatically
- can always be triggered from the header navigation, when on the /models page
- is in both English and Portuguese

~There are some WIP pieces - I attempted to have the tour set filters programmatically to demonstrate the change, but this doesn't seem to be fully executed. The last two steps - showing a cluster popup and also demoing the contextual layers - also is not yet working.~ Edit: Fixed and now fully operational