### PR TITLE
Make sidenav respect model order

### DIFF
--- a/src/app/downloads/download-list.tsx
+++ b/src/app/downloads/download-list.tsx
@@ -11,10 +11,10 @@ import { Search } from "@/components/ui/search";
 import {
   fetchVectors,
   fetchReferences,
-  fetchModels,
   type ApiFileResult,
   DataType,
 } from "@/utils/data-transformation";
+import { useModels } from "@/hooks/use-models";
 import { fetchRasters } from "@/utils/map/cog";
 import { SidebarFilter } from "./sidebar-filter";
 
@@ -29,9 +29,7 @@ export const DownloadList = () => {
   const { token, isAuthenticated } = useAuth();
   const { t } = useTranslation();
 
-  const { data: models } = useQuery({
-    queryKey: ["models", token],
-    queryFn: ({ signal }) => fetchModels(signal, token),
+  const { data: models } = useModels({
     enabled: isAuthenticated,
   });
 

--- a/src/app/model/[slug]/page.tsx
+++ b/src/app/model/[slug]/page.tsx
@@ -4,13 +4,14 @@ import Explorer from '@/components/ui/explorer';
 import { SideNav } from '@/components/layout/side-nav';
 import {
   fetchModels,
+  byPresentationOrder,
   slugify,
 } from '@/utils/data-transformation';
 
 export const dynamicParams = false;
 // Generate pages per model id
 export async function generateStaticParams() {
-  const res = await fetchModels();
+  const res = (await fetchModels()).toSorted(byPresentationOrder);
   return res.map((model) => ({
     slug: slugify(model.name),
   }));
@@ -22,7 +23,7 @@ export default async function ModelPage({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params;
-  const models = await fetchModels();
+  const models = (await fetchModels()).toSorted(byPresentationOrder);
   const model = models.find((m) => slugify(m.name) === slug);
 
   if (!model) {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,16 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import { Flex, Box, Spinner, Center, Heading, Text } from '@chakra-ui/react';
-import { useQuery } from '@tanstack/react-query';
 import Explorer from '@/components/ui/explorer';
 import { SideNav } from '@/components/layout/side-nav';
-import { fetchModels, slugify } from '@/utils/data-transformation';
-import { useAuth } from '@/utils/context/auth';
+import { slugify } from '@/utils/data-transformation';
+import { useModels } from '@/hooks/use-models';
 import { MapCoordsProvider } from '@/utils/context/map-coords';
 
 export default function NotFound() {
   const [slug, setSlug] = useState<string | null>(null);
-  const { token } = useAuth();
 
   useEffect(() => {
     const match = window.location.pathname.match(/^\/model\/([^/]+)\/?$/);
@@ -20,9 +18,7 @@ export default function NotFound() {
     }
   }, []);
 
-  const { data: models, isLoading } = useQuery({
-    queryKey: ['models', token],
-    queryFn: ({ signal }) => fetchModels(signal, token),
+  const { data: models, isLoading } = useModels({
     enabled: slug !== null,
   });
 

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -46,7 +46,6 @@ export interface Scenario {
   id: string;
   name: string;
   name_pt?: string;
-  presentation_order?: number;
   label: string;
   description?: string;
   source: SourceProps,

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -46,6 +46,7 @@ export interface Scenario {
   id: string;
   name: string;
   name_pt?: string;
+  presentation_order?: number;
   label: string;
   description?: string;
   source: SourceProps,
@@ -85,6 +86,7 @@ export interface ModelGroupMetadata {
   name: string;
   name_pt?: string;
   description: string;
+  presentation_order?: number;
   scenarios: Array<{ vector_dataset: { id: number } | null }>;
   description_pt?: string;
 }

--- a/src/components/layout/landing-models.tsx
+++ b/src/components/layout/landing-models.tsx
@@ -7,11 +7,8 @@ import ReactMarkdown from 'react-markdown';
 
 import NextLink from "next/link";
 import { ChakraDrawer } from '@/components/chakra/drawer';
-import {
-  useQuery
-} from '@tanstack/react-query';
-import { slugify, fetchModels } from '@/utils/data-transformation';
-import { useAuth } from '@/utils/context/auth';
+import { slugify } from '@/utils/data-transformation';
+import { useModels } from '@/hooks/use-models';
 import { useTranslation } from 'react-i18next';
 import { SimpleGrid, Text, Box } from '@chakra-ui/react';
 import { DrawerSummaryTable } from './drawer-summary-table';
@@ -19,18 +16,14 @@ import { LuArrowRight } from 'react-icons/lu';
 
 export default function ModelCards() {
   const { t } = useTranslation();
-  const { token } = useAuth();
   const [selectedModel, setSelectedModel] = useState<{ id: string; name: string; description: string; slug: string } | null>(null);
 
-  const { data: models } = useQuery({
-    queryKey: ['models', token],
-    queryFn: ({ signal }) => fetchModels(signal, token),
-  });
+  const { data: models } = useModels();
 
   return (
     <>
       <Heading size="3xl">Models</Heading>
-      <SimpleGrid columns={{ base: 1, md: 2 }} py={6} gap={6} minChildWidth={{base: "none",md: "md"}}>
+      <SimpleGrid columns={{ base: 1, md: 2 }} py={6} gap={6} minChildWidth={{ base: "none",md: "md" }}>
         {models?.map(e => (
           <div key={e.id} onClick={() => setSelectedModel({ id: String(e.id), name: t(`model.${e.id}.name`, { defaultValue: e.name }), description: t(`model.${e.id}.description`, { defaultValue: e.description }), slug: slugify(e.name) })} style={{ cursor: 'pointer' }}>
             <Card title={t(`model.${e.id}.name`, { defaultValue: e.name })} description={t(`model.${e.id}.description`, { defaultValue: e.description })} />

--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -6,12 +6,14 @@ import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { createSerializer } from 'nuqs/server';
 import { ModelGroupMetadata } from '@/app/types';
-import { slugify } from '@/utils/data-transformation';
+import { slugify, fetchModels } from '@/utils/data-transformation';
 import { zIndex } from '@/components/ui/constant';
 import { getIconPath } from '@/utils/model-icon';
 import { coordinateParsers } from '@/utils/context/map-coords';
 import { Tooltip } from '../ui/tooltip';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/utils/context/auth';
 
 //Generate URL with coordinates
 const serialize = createSerializer(coordinateParsers);
@@ -21,9 +23,16 @@ interface SideNavProps {
   currentSlug: string;
 }
 
-export const SideNav = ({ models, currentSlug }: SideNavProps) => {
+export const SideNav = ({ models: initialModels, currentSlug }: SideNavProps) => {
   const searchParams = useSearchParams();
   const { t } = useTranslation();
+  const { token } = useAuth();
+
+  const { data: models = initialModels } = useQuery({
+    queryKey: ['models', token],
+    queryFn: ({ signal }) => fetchModels(signal, token),
+    initialData: initialModels,
+  });
   // Only carry coordinate params (lat, lng, zoom) to model links
       const coordQuery = serialize({
       lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : null,

--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -2,8 +2,8 @@ import { memo, useState, useEffect } from "react";
 import { Box, Flex, Text, IconButton, Link } from "@chakra-ui/react";
 import NextLink from "next/link";
 import { api } from "@/utils/api";
-import { fetchModels, slugify } from "@/utils/data-transformation";
-import { useAuth } from "@/utils/context/auth";
+import { slugify } from "@/utils/data-transformation";
+import { useModels } from "@/hooks/use-models";
 import { useModel } from "@/utils/context/model";
 import { LuChevronLeft, LuChevronsUpDown, LuChevronsDownUp } from "react-icons/lu";
 import { useQuery } from "@tanstack/react-query";
@@ -75,11 +75,7 @@ interface RelatedModelsProps {
 
 const RelatedModels = ({ clusterId }: RelatedModelsProps) => {
   const { model } = useModel();
-  const { token } = useAuth();
-  const { data: models } = useQuery({
-    queryKey: ["models", token],
-    queryFn: ({ signal }) => fetchModels(signal, token),
-  });
+  const { data: models } = useModels();
   const { t } = useTranslation();
 
   const currentModelData = models?.find((m) => String(m.id) === model.id);

--- a/src/components/ui/model-switcher-menu.tsx
+++ b/src/components/ui/model-switcher-menu.tsx
@@ -3,21 +3,16 @@
 import { Text, Box, Flex, MenuRoot, Menu, MenuTrigger, MenuContent, MenuItem } from "@chakra-ui/react";
 import Image from "next/image";
 import NextLink from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import { useModel } from "@/utils/context/model";
-import { fetchModels, slugify } from "@/utils/data-transformation";
-import { useAuth } from "@/utils/context/auth";
+import { slugify } from "@/utils/data-transformation";
+import { useModels } from "@/hooks/use-models";
 import { getIconPath } from "@/utils/model-icon";
 import { zIndex } from "@/components/ui/constant";
 
 const ModelSwitcherMenu = () => {
   const { model } = useModel();
-  const { token } = useAuth();
 
-  const { data: models } = useQuery({
-    queryKey: ["models", token],
-    queryFn: ({ signal }) => fetchModels(signal, token),
-  });
+  const { data: models } = useModels();
 
   const iconPath = getIconPath(model.id);
 

--- a/src/hooks/use-models.ts
+++ b/src/hooks/use-models.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { useAuth } from "@/utils/context/auth";
+import { fetchModels, byPresentationOrder } from "@/utils/data-transformation";
+import { type ModelGroupMetadata } from "@/app/types";
+
+export function useModels(
+  options?: Omit<UseQueryOptions<ModelGroupMetadata[], Error, ModelGroupMetadata[]>, "queryKey" | "queryFn" | "select">
+) {
+  const { token } = useAuth();
+  return useQuery({
+    queryKey: ["models", token],
+    queryFn: ({ signal }) => fetchModels(signal, token),
+    select: (data) => data.toSorted(byPresentationOrder),
+    ...options,
+  });
+}

--- a/src/utils/data-transformation.ts
+++ b/src/utils/data-transformation.ts
@@ -40,6 +40,7 @@ export interface ApiScenario {
   id: number;
   name: string;
   name_pt?: string;
+  presentation_order?: number;
   description?: string;
   description_pt?: string;
   model_file: string | null;
@@ -200,6 +201,12 @@ export function deriveLayerStyles(sourceId: string, color: string, opacity: numb
   };
 }
 
+export function byPresentationOrder(a: { presentation_order?: number | null }, b: { presentation_order?: number | null }) {
+  if (!a.presentation_order) return 1;
+  if (!b.presentation_order) return -1;
+  return a.presentation_order - b.presentation_order;
+}
+
 export async function fetchModels(signal?: AbortSignal, token?: string| null): Promise<ModelGroupMetadata[]> {
   const { data } = await api.get('model/', { signal, ...(token && {
       headers: { 'Authorization': `Token ${token}` }
@@ -327,9 +334,8 @@ export function transformModelCore(apiModel: ApiModelResponse): Omit<ModelMetada
   });
 
   const scenarios: Scenario[] = apiModel.scenarios
-    // @TODO: Filtering LCOE model until performance improvement
-    // .filter(s => s.id !== 1)
     .filter(s => s.model_file !== null)
+    .toSorted(byPresentationOrder)
     .map(s => {
       registerI18nResource(`scenario.${s.id}`, {
         name: { en: s.name, pt: s.name_pt },


### PR DESCRIPTION
Use the model order from the API to order the model icons in the side-nav.

This sets the initial model order according to the hard-coded order in the frontend config, but then updates on the initial fetch of data just like the `/models` page.

I've tested this by changing the order of models in the admin, and it works as expected.