### PR TITLE
Display error toast if scenario not found or invalid

### DIFF
--- a/src/app/model/error.tsx
+++ b/src/app/model/error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Center, Box, Heading, Text, Button } from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+export default function ModelError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <Center h="calc(100vh - 3.5rem - 1px)">
+      <Box textAlign="center">
+        <Heading size="2xl">500</Heading>
+        <Text mt={2}>{error.message || 'An unexpected error occurred.'}</Text>
+        <Button mt={4} variant="outline" onClick={reset}>
+          Try again
+        </Button>
+        <Box mt={2} textDecoration="underline">
+          <NextLink href="/models">{t('explorer.returnToModels')}</NextLink>
+        </Box>
+      </Box>
+    </Center>
+  );
+}

--- a/src/components/chakra/provider.tsx
+++ b/src/components/chakra/provider.tsx
@@ -5,7 +5,7 @@ import {
   type ColorModeProviderProps,
 } from "./color-mode";
 import { system } from "./theme";
-import { Toaster } from "../ui/toaster";
+import { Toaster } from "./toaster";
 
 export function Provider(props: ColorModeProviderProps) {
   return (

--- a/src/components/chakra/provider.tsx
+++ b/src/components/chakra/provider.tsx
@@ -5,11 +5,13 @@ import {
   type ColorModeProviderProps,
 } from "./color-mode";
 import { system } from "./theme";
+import { Toaster } from "../ui/toaster";
 
 export function Provider(props: ColorModeProviderProps) {
   return (
     <ChakraProvider value={system}>
       {props.children}
+      <Toaster />
       {/* <ColorModeProvider {...props} /> */}
     </ChakraProvider>
   );

--- a/src/components/chakra/toaster.tsx
+++ b/src/components/chakra/toaster.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import {
   Toaster as ChakraToaster,
@@ -7,12 +7,12 @@ import {
   Stack,
   Toast,
   createToaster,
-} from "@chakra-ui/react"
+} from "@chakra-ui/react";
 
 export const toaster = createToaster({
   placement: "bottom-end",
   pauseOnPageIdle: true,
-})
+});
 
 export const Toaster = () => {
   return (
@@ -39,5 +39,5 @@ export const Toaster = () => {
         )}
       </ChakraToaster>
     </Portal>
-  )
-}
+  );
+};

--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -83,7 +83,8 @@ const MainMap = ({ main, onClick, clusterId, onFlyToRef }: MainMapProps) => {
     return buildExpressionWithFilter(model.filters, updatedFilters);
   }, [updatedFilters, model.filters]);
 
-  const scenario = model.scenarios.find((s) => s.id === scenarioId)!;
+  const scenario = model.scenarios.find((s) => s.id === scenarioId);
+  if (!scenario) return null;
 
   const [mainLayerOpacity, setMainLayerOpacity] = useState(100);
   const [currentBasemapId, setCurrentBasemapId] = useState("light");

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -31,6 +31,7 @@ import SummaryPanel from "@/components/map/summary-panel";
 import { Tooltip } from "./tooltip";
 import { useTranslation } from "react-i18next";
 import { useToggle } from "@/hooks/use-toggle";
+import { toaster } from "./toaster";
 import { useMouseEvent } from "@/components/map/hooks/use-mouse-event";
 import { ControlPanelWidth, AnimationTime } from "./main-panel";
 
@@ -243,6 +244,19 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
   // Scenario state (lifted from ModelProvider so filter query can react to changes)
   const [scenarioId, setScenarioId] = useQueryState('scenario', parseAsString);
   const activeScenarioId = scenarioId ?? defaultScenarioId;
+
+  // Validate scenarioId against known scenarios once model loads
+  useEffect(() => {
+    if (!modelCore || !scenarioId) return;
+    const valid = modelCore.scenarios.some((s) => s.id === scenarioId);
+    if (!valid) {
+      setScenarioId(null);
+      toaster.create({
+        type: "error",
+        title: t('explorer.invalidScenario'),
+      });
+    }
+  }, [modelCore, scenarioId, setScenarioId, t]);
 
   // Filter options (single batch fetch, refetches per scenario)
   const filterColumns = (modelCore?.filterFields ?? []).map((f) => f.column);

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -31,7 +31,7 @@ import SummaryPanel from "@/components/map/summary-panel";
 import { Tooltip } from "./tooltip";
 import { useTranslation } from "react-i18next";
 import { useToggle } from "@/hooks/use-toggle";
-import { toaster } from "./toaster";
+import { toaster } from "../chakra/toaster";
 import { useMouseEvent } from "@/components/map/hooks/use-mouse-event";
 import { ControlPanelWidth, AnimationTime } from "./main-panel";
 
@@ -250,13 +250,13 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
     if (!modelCore || !scenarioId) return;
     const valid = modelCore.scenarios.some((s) => s.id === scenarioId);
     if (!valid) {
-      setScenarioId(null);
+      setScenarioId(defaultScenarioId?? null);
       toaster.create({
         type: "error",
         title: t('explorer.invalidScenario'),
       });
     }
-  }, [modelCore, scenarioId, setScenarioId, t]);
+  }, [modelCore, scenarioId, setScenarioId, t, defaultScenarioId]);
 
   // Filter options (single batch fetch, refetches per scenario)
   const filterColumns = (modelCore?.filterFields ?? []).map((f) => f.column);
@@ -325,11 +325,11 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
   if (!modelData || !layers) {
     return (
       <Flex id="container" width="full" height="full" position="relative" direction={{ base: "column", md: "row" }}>
-        <Skeleton width={{ base: "full", md: ControlPanelWidth }} height={{ base: "auto", md: "full" }} flex={{base: 1, md: "initial" }} />
+        <Skeleton width={{ base: "full", md: ControlPanelWidth }} height={{ base: "auto", md: "full" }} flex={{ base: 1, md: "initial" }} />
         <Box flex={{ base: 4, md: 1 }} height="full" p={2}>
           <Skeleton width="full" height="full" />
         </Box>
-        <Skeleton width={{ base: "full", md: ControlPanelWidth }} height="full" flex={{base: 1, md: "initial" }} />
+        <Skeleton width={{ base: "full", md: ControlPanelWidth }} height="full" flex={{ base: 1, md: "initial" }} />
       </Flex>
     );
   }

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import {
+  Toaster as ChakraToaster,
+  Portal,
+  Spinner,
+  Stack,
+  Toast,
+  createToaster,
+} from "@chakra-ui/react"
+
+export const toaster = createToaster({
+  placement: "bottom-end",
+  pauseOnPageIdle: true,
+})
+
+export const Toaster = () => {
+  return (
+    <Portal>
+      <ChakraToaster toaster={toaster} insetInline={{ mdDown: "4" }}>
+        {(toast) => (
+          <Toast.Root width={{ md: "sm" }}>
+            {toast.type === "loading" ? (
+              <Spinner size="sm" color="blue.solid" />
+            ) : (
+              <Toast.Indicator />
+            )}
+            <Stack gap="1" flex="1" maxWidth="100%">
+              {toast.title && <Toast.Title>{toast.title}</Toast.Title>}
+              {toast.description && (
+                <Toast.Description>{toast.description}</Toast.Description>
+              )}
+            </Stack>
+            {toast.action && (
+              <Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger>
+            )}
+            {toast.closable && <Toast.CloseTrigger />}
+          </Toast.Root>
+        )}
+      </ChakraToaster>
+    </Portal>
+  )
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -62,7 +62,8 @@
     "onlyBarChart": "Only Bar Chart is available.",
     "errorNotReady": "This data doesn't look like it is ready. Make sure there are scenarios related to this model.",
     "returnToModels": "Return to models",
-    "relatedClusters": "View cluster in other models"
+    "relatedClusters": "View cluster in other models",
+    "invalidScenario": "Selected scenario was not found; the default scenario has been loaded."
   },
   "downloads": {
     "title": "Downloads",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -62,7 +62,8 @@
     "onlyBarChart": "Apenas Gráfico de Barras está disponível.",
     "errorNotReady": "Estes dados não parecem estar prontos. Certifique-se de que existem cenários relacionados a este modelo.",
     "returnToModels": "Voltar para modelos",
-    "relatedClusters": "Ver cluster em outros modelos"
+    "relatedClusters": "Ver cluster em outros modelos",
+    "invalidScenario": "O cenário selecionado não foi encontrado; o cenário padrão foi carregado."
   },
   "downloads": {
     "title": "Downloads",


### PR DESCRIPTION
Fixes #149.

If a scenario id is invalid or throws a 404, application will now display an error toast rather than completely fail.

https://github.com/user-attachments/assets/871e0a82-4db5-428a-ab9f-8bd7bbc08d12

AI contribution: The code in this PR was generated by claude code. I ran and tested all code, and updated the Chakra UI Toaster component and provider manually. The business logic for checking the existence of a valid scenario id, and creating a fallback page and error handling, was all from Claude outputs.
