### PR TITLE
Feat: add error states to React Query fetches

### DIFF
--- a/src/app/downloads/download-list.tsx
+++ b/src/app/downloads/download-list.tsx
@@ -166,6 +166,14 @@ export const DownloadList = () => {
       rasterResults.some((r) => r.isPending) ||
       referenceResults.some((r) => r.isPending));
 
+  const isError =
+    vectorAllResult.isError ||
+    rasterAllResult.isError ||
+    referenceAllResult.isError ||
+    vectorResults.some((r) => r.isError) ||
+    rasterResults.some((r) => r.isError) ||
+    referenceResults.some((r) => r.isError);
+
   const toggleModel = (id: string) => {
     setSelectedModelIds((prev) =>
       prev.includes(id) ? prev.filter((m) => m !== id) : [...prev, id],
@@ -203,6 +211,10 @@ export const DownloadList = () => {
         {isInitialLoading ? (
           <Center py={10}>
             <Spinner colorPalette="orange" color="colorPalette.600" size="lg" />
+          </Center>
+        ) : isError ? (
+          <Center py={10}>
+            <Text color="fg.muted">{t("downloads.loadError")}</Text>
           </Center>
         ) : (
           <>

--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -184,7 +184,7 @@ const SummaryPanel = ({
     return () => clearTimeout(id);
   }, []);
 
-  const { data: summaryData, isLoading: summaryIsLoading } = useSummaryQuery({
+  const { data: summaryData, isLoading: summaryIsLoading, isError: summaryIsError } = useSummaryQuery({
     scenarioId,
     summaryFields,
     filters,
@@ -199,6 +199,7 @@ const SummaryPanel = ({
   const isLoading = showingCluster
     ? clusterIsLoading || clusterIsFetching
     : summaryIsLoading;
+  const isError = showingCluster ? clusterIsError : summaryIsError;
 
   const title = showingCluster
     ? t('explorer.cluster', { clusterId })
@@ -217,7 +218,7 @@ const SummaryPanel = ({
         <SummaryTable
           data={dataToDisplay}
           isLoading={isLoading}
-          isError={showingCluster && clusterIsError}
+          isError={isError}
           collapsible={!showingCluster}
         />
       </Box>

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -184,7 +184,7 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
   const { t } = useTranslation();
 
   // Query 1: Model metadata
-  const { data: modelCore } = useQuery({
+  const { data: modelCore, isError: modelCoreError } = useQuery({
     queryKey: ["modelMetadata", modelId, token],
     queryFn: async ({ signal }) => {
       const apiModel = await fetchModelMetadata(modelId, signal, token);
@@ -301,6 +301,17 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
         <Box>
           {t('explorer.errorNotReady')}
         </Box>
+        <Box mt={4} textDecoration="underline">
+          <NextLink href="/models">{t('explorer.returnToModels')}</NextLink>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (modelCoreError) {
+    return (
+      <Box h="full" w="full" display="flex" justifyContent="center" alignItems="center" flexDirection="column">
+        <Box>{t('explorer.loadError')}</Box>
         <Box mt={4} textDecoration="underline">
           <NextLink href="/models">{t('explorer.returnToModels')}</NextLink>
         </Box>

--- a/src/hooks/use-summary-query.ts
+++ b/src/hooks/use-summary-query.ts
@@ -138,6 +138,7 @@ export function useSummaryQuery({
     : undefined;
 
   const isLoading = queries.some((q) => q.isLoading);
+  const isError = !isLoading && queries.every((q) => q.isError);
 
-  return { data, isLoading };
+  return { data, isLoading, isError };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -62,6 +62,7 @@
     "onlyBarChart": "Only Bar Chart is available.",
     "errorNotReady": "This data doesn't look like it is ready. Make sure there are scenarios related to this model.",
     "returnToModels": "Return to models",
+    "loadError": "Failed to load model data. Please try again later.",
     "relatedClusters": "View cluster in other models"
   },
   "downloads": {
@@ -73,6 +74,7 @@
     "download": "Download",
     "filterModels": "Filter by Model",
     "reset": "Reset",
+    "loadError": "Failed to load datasets. Please try again later.",
     "dataType": {
       "vector": "Vector",
       "raster": "Raster",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -62,6 +62,7 @@
     "onlyBarChart": "Apenas Gráfico de Barras está disponível.",
     "errorNotReady": "Estes dados não parecem estar prontos. Certifique-se de que existem cenários relacionados a este modelo.",
     "returnToModels": "Voltar para modelos",
+    "loadError": "Falha ao carregar dados do modelo. Por favor, tente novamente mais tarde.",
     "relatedClusters": "Ver cluster em outros modelos"
   },
   "downloads": {
@@ -73,6 +74,7 @@
     "download": "Baixar",
     "filterModels": "Filtrar por Modelo",
     "reset": "Redefinir",
+    "loadError": "Falha ao carregar conjuntos de dados. Por favor, tente novamente mais tarde.",
     "dataType": {
       "vector": "Vetorial",
       "raster": "Raster",

--- a/src/test/download-list-error.test.tsx
+++ b/src/test/download-list-error.test.tsx
@@ -1,0 +1,70 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "@/components/chakra/provider";
+
+vi.mock("@/utils/context/auth", () => ({
+  useAuth: () => ({ token: "test-token", isAuthenticated: true }),
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/hooks/use-models", () => ({
+  useModels: () => ({ data: [{ id: "1", name: "Model A" }] }),
+}));
+
+vi.mock("@/utils/data-transformation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/data-transformation")>()),
+  fetchVectors: vi.fn().mockRejectedValue(new Error("Network error")),
+  fetchReferences: vi.fn().mockRejectedValue(new Error("Network error")),
+}));
+
+vi.mock("@/utils/map/cog", () => ({
+  fetchRasters: vi.fn().mockRejectedValue(new Error("Network error")),
+}));
+
+import { DownloadList } from "@/app/downloads/download-list";
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <Provider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+};
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe("DownloadList error state", () => {
+  it("shows error message when dataset fetches fail", async () => {
+    render(<DownloadList />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText("downloads.loadError")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show any dataset cards when errored", async () => {
+    render(<DownloadList />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText("downloads.loadError")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("article")).not.toBeInTheDocument();
+  });
+});

--- a/src/test/explorer-error-state.test.tsx
+++ b/src/test/explorer-error-state.test.tsx
@@ -1,0 +1,84 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { Provider } from "@/components/chakra/provider";
+
+// Mock heavy dependencies that are irrelevant to the error state
+vi.mock("@/utils/context/auth", () => ({
+  useAuth: () => ({ token: null, isAuthenticated: false }),
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/utils/context/map-coords", () => ({
+  useMapCoords: () => ({ coords: { lat: 0, lng: 0, zoom: 5 }, setCoords: vi.fn(), removeCoordinates: vi.fn() }),
+  MapCoordsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/utils/data-transformation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/data-transformation")>()),
+  fetchModelMetadata: vi.fn().mockRejectedValue(new Error("404 Not Found")),
+  fetchVectors: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/utils/map/cog", () => ({
+  fetchRasters: vi.fn().mockResolvedValue([]),
+  fetchCogMetadata: vi.fn().mockResolvedValue(null),
+  transformRastersToLayers: vi.fn().mockReturnValue([]),
+}));
+
+import ExplorerContent from "@/components/ui/explorer";
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <Provider>
+      <QueryClientProvider client={queryClient}>
+        <NuqsTestingAdapter>{children}</NuqsTestingAdapter>
+      </QueryClientProvider>
+    </Provider>
+  );
+};
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe("ExplorerContent error state", () => {
+  it("shows error message when modelMetadata fetch fails", async () => {
+    render(<ExplorerContent modelId="1" />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText("explorer.loadError")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a return to models link when modelMetadata fetch fails", async () => {
+    render(<ExplorerContent modelId="1" />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "explorer.returnToModels" })).toHaveAttribute(
+        "href",
+        "/models"
+      );
+    });
+  });
+});

--- a/src/test/use-summary-query-error.test.tsx
+++ b/src/test/use-summary-query-error.test.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/utils/api", () => ({
+  api: { get: vi.fn() },
+}));
+
+vi.mock("@/utils/query-string-builder", () => ({
+  buildFilterQueryParam: vi.fn(() => ""),
+}));
+
+import { useSummaryQuery } from "@/hooks/use-summary-query";
+import { api } from "@/utils/api";
+import type { Field } from "@/app/types";
+
+const mockGet = api.get as ReturnType<typeof vi.fn>;
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const fields: Field[] = [
+  { columns: ["PopStartYear"], label: "Population", method: "sum" },
+];
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe("useSummaryQuery isError", () => {
+  it("returns isError=false while loading", () => {
+    mockGet.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(
+      () => useSummaryQuery({ scenarioId: "s1", summaryFields: fields }),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns isError=true when all queries fail", async () => {
+    mockGet.mockRejectedValue(new Error("500"));
+
+    const { result } = renderHook(
+      () => useSummaryQuery({ scenarioId: "s1", summaryFields: fields }),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("returns isError=false on success", async () => {
+    mockGet.mockResolvedValue({
+      data: { PopStartYear: { count: 100, sum: 5000 } },
+    });
+
+    const { result } = renderHook(
+      () => useSummaryQuery({ scenarioId: "s1", summaryFields: fields }),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("returns isError=false when disabled", () => {
+    const { result } = renderHook(
+      () =>
+        useSummaryQuery({ scenarioId: "s1", summaryFields: fields, enabled: false }),
+      { wrapper: makeWrapper() }
+    );
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+});


### PR DESCRIPTION
The below PR is generated by Claude. I've tested the code according to the test steps described. This was suggested by Claude in a thread about error handling where the LLM pointed out that the codebase has a silent failure: queries that fail and leave components in a permanently loading or empty state with no user feedback. 

## Summary

- `ExplorerContent`: when the `modelMetadata` fetch fails, the user now sees an error message and a "Return to models" link instead of a skeleton that never resolves
- `useSummaryQuery`: exposes `isError` (true only when all queries have failed and loading is complete); wired through `SummaryPanel` to the existing `SummaryTable` error UI, covering both cluster and national summary failures
- `DownloadList`: a failed dataset fetch now shows an inline error message in place of the dataset list rather than rendering nothing

## Test plan

- [ ] In `ExplorerContent` queryFn, add `throw new Error("test")` — confirm error message and "Return to models" link appear instead of skeleton
- [ ] In `useSummaryQuery` queryFn, add `throw new Error("test")` —  confirm `SummaryTable` shows its error state in the summary panel
- [ ] In `DownloadList`, set `const isError = true` temporarily — confirm error message replaces the dataset list
- [ ] Run `pnpm test:run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)