### PR TITLE
Add user guide link to nav, and link titles

### DIFF
--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -5,17 +5,18 @@ import { usePathname } from "next/navigation";
 import { Box, Heading, Flex, HStack, Text, Link, Separator, Drawer, CloseButton, IconButton, Portal, VStack, Button } from "@chakra-ui/react";
 import NextLink from "next/link";
 import Image from "next/image";
-import { LuDownload, LuInfo, LuMap, LuMenu } from "react-icons/lu";
+import { LuBookOpen, LuDownload, LuInfo, LuMap, LuMenu } from "react-icons/lu";
 import DropdownMenu, { DropdownMenuItems } from "./dropdown-menu";
 import { LanguageSwitcher } from "./language-switcher";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/utils/context/auth";
 import { zIndex } from "@/components/ui/constant";
-import { BASE_PATH } from "@/config/website";
+import { BASE_PATH, USER_GUIDE_URL } from "@/config/website";
 
 export interface NavigationItem {
   label: string;
   href: string;
+  title: string;
   icon: React.ReactNode;
 }
 
@@ -32,9 +33,9 @@ export const Header = ({
   const { isAuthenticated } = useAuth();
 
   const navigationItems: NavigationItem[] = [
-    { label: t('nav.explorer'), href: "/models", icon: <LuMap size={20} /> },
-    { label: t('nav.about'), href: "/about", icon: <LuInfo size={20} /> },
-    { label: t('nav.downloads'), href: "/downloads", icon: <LuDownload size={20} /> },
+    { label: t('nav.explorer'), href: "/models", title: t('nav.explorerTitle'), icon: <LuMap size={20} /> },
+    { label: t('nav.about'), href: "/about", title: t('nav.aboutTitle'), icon: <LuInfo size={20} /> },
+    { label: t('nav.downloads'), href: "/downloads", title: t('nav.downloadsTitle'), icon: <LuDownload size={20} /> },
   ];
 
   const isActive = (href: string) => {
@@ -103,6 +104,7 @@ export const Header = ({
                   variant="ghost"
                   asChild
                   _hover={{ bg: "orange.fg", color: "orange.subtle" }}
+                  title={item.title}
                 >
                     <NextLink href={item.href}>
                       {item.icon}
@@ -111,6 +113,26 @@ export const Header = ({
                 </Button>
               );
             })}
+            {USER_GUIDE_URL && (
+              <Button
+                fontSize="sm"
+                fontWeight="semibold"
+                colorPalette="orange"
+                size="sm"
+                px={2}
+                bg="transparent"
+                color="orange.contrast"
+                variant="ghost"
+                asChild
+                _hover={{ bg: "orange.fg", color: "orange.subtle" }}
+                title={t('nav.userGuideTitle')}
+              >
+                <a href={USER_GUIDE_URL} target="_blank" rel="noopener noreferrer">
+                  <LuBookOpen size={20} />
+                  {t('nav.userGuide')}
+                </a>
+              </Button>
+            )}
             <Separator orientation="vertical" height="4" />
             <LanguageSwitcher />
             <Separator orientation="vertical" height="4" />
@@ -154,10 +176,28 @@ export const Header = ({
                             asChild
                             _hover={{ textDecoration: "none", color: "fg" }}
                             onClick={() => setDrawerOpen(false)}
+                            title={item.title}
                           >
                             <NextLink href={item.href}>{item.icon}{item.label}</NextLink>
                           </Link>
                         )})}
+                        {USER_GUIDE_URL && (
+                          <Link
+                            fontSize="sm"
+                            fontWeight="medium"
+                            color="fg.muted"
+                            href={USER_GUIDE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            display="flex"
+                            alignItems="center"
+                            gap={1.5}
+                            title={t('nav.userGuideTitle')}
+                            _hover={{ textDecoration: "none", color: "fg" }}
+                          >
+                            <LuBookOpen size={20} /> {t('nav.userGuide')}
+                          </Link>
+                        )}
                         <Separator mt="auto" />
                         <LanguageSwitcher />
                         <Separator />

--- a/src/config/website.ts
+++ b/src/config/website.ts
@@ -1,6 +1,7 @@
 export const WEBSITE_TITLE = "Plataforma Integrada de Electrificação de Moçambique - PIE";
 export const WEBSITE_DESC = "Proenergia";
 export const SDI_PORTAL_URL = "https://proenergia-staging.ds.io/admin/";
+export const USER_GUIDE_URL = "https://developmentseed.org/moz-proenergia-docs/";
 
 // BASE_PATH is set via the `NEXT_PUBLIC_BASE_PATH` env var at build time.
 // The `build-prod` npm script (used by Netlify) sets it to `/app`.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,11 +4,16 @@
     "longName": "Integrated Energy Planning Platform",
     "shortName": "PIE",
     "explorer": "Explorer",
+    "explorerTitle": "Explore models and scenarios",
     "about": "About",
+    "aboutTitle": "Learn more about the project",
     "downloads": "Downloads",
+    "downloadsTitle": "Download resources",
     "login": "Login",
     "logout": "Log out",
     "sdiPortal": "SDI Portal",
+    "userGuide": "User Guide",
+    "userGuideTitle": "Visit the User Guide",
     "menu": "Menu"
   },
   "home": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -4,11 +4,16 @@
     "longName": "Plataforma Integrada de Electrificação",
     "shortName": "PIE",
     "explorer": "Explorador",
+    "explorerTitle": "Explorar modelos e cenários",
     "about": "Sobre",
+    "aboutTitle": "Saber mais sobre o projeto",
     "downloads": "Downloads",
+    "downloadsTitle": "Descarregar recursos",
     "login": "Entrar",
     "logout": "Sair",
     "sdiPortal": "Portal SDI",
+    "userGuide": "Guia do Utilizador",
+    "userGuideTitle": "Visitar o Guia do Utilizador",
     "menu": "Menu"
   },
   "home": {


### PR DESCRIPTION
Adds users guide link to main header, and adds link hover titles with translation strings. Closes #151.

This also adds the documentation site URL to the website config.ts file; this should be added to the documentation as something to update per environment.