### PR TITLE
Edit number format to show 2 significan digits (rather than 2 decimal places)

### DIFF
--- a/src/test/number.test.ts
+++ b/src/test/number.test.ts
@@ -46,16 +46,18 @@ describe('formatDisplayNumber', () => {
     });
   });
 
-  describe('hasDecimal=true (preserves decimals)', () => {
-    it('keeps decimals for sub-thousand values', () => {
+  describe('hasDecimal=true (significant figures for values < 1, two decimal places otherwise)', () => {
+    it('keeps up to two decimal places for values >= 1', () => {
       expect(formatDisplayNumber(12.3, true)).toBe('12.3');
       expect(formatDisplayNumber(12.34, true)).toBe('12.34');
+      expect(formatDisplayNumber(999.4, true)).toBe('999.4');
+      expect(formatDisplayNumber(999.99, true)).toBe('999.99');
     });
 
-    it('does not round before the compact threshold check', () => {
-      // 999.99 stays below 1000 and is formatted without compact notation.
-      expect(formatDisplayNumber(999.99, true)).toBe('999.99');
-      expect(formatDisplayNumber(999.4, true)).toBe('999.4');
+    it('uses 2 significant figures for values < 1 to preserve small numbers', () => {
+      expect(formatDisplayNumber(0.0045, true)).toBe('0.0045');
+      expect(formatDisplayNumber(0.001234, true)).toBe('0.0012');
+      expect(formatDisplayNumber(0.5, true)).toBe('0.5');
     });
 
     it('abbreviates thousands while capping at two fraction digits', () => {

--- a/src/utils/number.tsx
+++ b/src/utils/number.tsx
@@ -1,4 +1,5 @@
 const formatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
+const decimalFormatter = new Intl.NumberFormat("en-US", { maximumSignificantDigits: 2 });
 const stringFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
   compactDisplay: "short",
@@ -7,10 +8,15 @@ const stringFormatter = new Intl.NumberFormat("en-US", {
 
 export const formatNumber = formatter.format.bind(formatter);
 
-// Values are integers by default; pass hasDecimal=true to preserve decimal places.
+// Values are integers by default; pass hasDecimal=true to use significant-figure display.
 export function formatDisplayNumber(value: number, hasDecimal?: boolean): string {
   const num = hasDecimal ? value : Math.round(value);
   // Use compact notation for large numbers (1K, 1M, 1.23B…)
   if (Math.abs(num) >= 1_000) return stringFormatter.format(num);
+  if (hasDecimal) {
+    // For values < 1, use significant figures so small numbers like 0.0045 aren't shown as "0.00"
+    if (num !== 0 && Math.abs(num) < 1) return decimalFormatter.format(num);
+    return formatNumber(num);
+  }
   return formatNumber(num);
 }


### PR DESCRIPTION
I can't seem to find a combination where I can actually check if this works - but this should display 0.00213 as 0.0021, not 0. 