### PR TITLE
Ensure summary highlight chart can show decimals

### DIFF
--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -402,7 +402,7 @@ function HighlightRowView({ row }: { row: HighlightRow }) {
   const label = localize(row.label, row.label_pt);
   const description = row.description ? localize(row.description, row.description_pt) : undefined;
   const items = row.value.map((item) => ({
-    id: String(formatValue(item.value)),
+    id: String(formatValue(item.value, row.hasDecimal)),
     label: item.label,
   }));
   return (

--- a/src/utils/summary.ts
+++ b/src/utils/summary.ts
@@ -191,6 +191,7 @@ export function transformFieldSummary(
         description_pt: field.description_pt,
         unit: field.unit,
         value: [{ key: column, label: makeLabel(column), value: getNumericValue(summary, methodName) }],
+        hasDecimal: field.hasDecimal,
       };
     }
 


### PR DESCRIPTION
Allows decimals in the highlight summary chart.

See the "Levelized Cost of Electricity" highlight chart in the screenshots below.
Before | After
-- | --
<img width="1364" height="1323" alt="image" src="https://github.com/user-attachments/assets/534e0d1d-da0c-4485-993f-39c29419f266" /> | <img width="1364" height="1323" alt="image" src="https://github.com/user-attachments/assets/c9563730-b496-462d-9e65-9c2710b3fca7" />
