### PR TITLE
Enable rendering unit and decimals for cluster data

### DIFF
--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -127,6 +127,8 @@ function transformClusterData(
       label_pt: field.label_pt,
       description_pt: field.description_pt,
       value: data[field.columns[0]],
+      unit: field.unit,
+      hasDecimal: field.hasDecimal,
     }));
 }
 

--- a/src/utils/data-transformation.ts
+++ b/src/utils/data-transformation.ts
@@ -35,6 +35,8 @@ export interface ApiFilterField {
   column: string;
   description: string;
   description_pt?: string;
+  unit?: string;
+  hasDecimal?: boolean;
 }
 
 export interface ApiField {
@@ -387,6 +389,8 @@ export function transformModelCore(apiModel: ApiModelResponse): Omit<ModelMetada
       label_pt: f.label_pt,
       description: f.description,
       description_pt: f.description_pt,
+      unit: f.unit,
+      hasDecimal: f.hasDecimal,
     })),
     summaryFields: summaryFields,
     filterFields: apiModel.filter_fields,


### PR DESCRIPTION
Allows the display of decimal values on the cluster popup summary table if admins mark `hasDecimal: true` on the backend for popup fields. Unit was already permitted from the backend, but not processed on the frontend. (Also not yet displayed, but setting up for future integration if needed).

<img width="353" height="387" alt="image" src="https://github.com/user-attachments/assets/852aab8a-a788-4cfe-99cd-f179a08a555b" />
