### PR TITLE
Improve SDI_PORTAL_BASE_URL setting

### DIFF
--- a/src/config/website.ts
+++ b/src/config/website.ts
@@ -1,6 +1,6 @@
 export const WEBSITE_TITLE = "Plataforma Integrada de Electrificação de Moçambique - PIE";
 export const WEBSITE_DESC = "Uma plataforma web para planejamento e análise integrada de energia em Moçambique. O Proenergia+ IEP visa aumentar o acesso à energia e serviços de banda larga nas áreas do projeto e fortalecer o desempenho operacional da concessionária elétrica.";
-export const SDI_PORTAL_BASE_URL = "https://proenergia-staging.ds.io/";
+export const SDI_PORTAL_BASE_URL = process.env.NEXT_PUBLIC_BASE_PATH ? "../" : "https://proenergia-staging.ds.io/";
 export const USER_GUIDE_URL = "https://developmentseed.org/moz-proenergia-docs/";
 
 // BASE_PATH is set via the `NEXT_PUBLIC_BASE_PATH` env var at build time.


### PR DESCRIPTION
Related to #170

To avoid having to configure SDI_PORTAL_BASE_URL with an env var, we are setting it as `"../"`, if `NEXT_PUBLIC_BASE_PATH` is not empty.