### PR TITLE
Fix/missing translations

### DIFF
--- a/src/app/model/error.tsx
+++ b/src/app/model/error.tsx
@@ -22,9 +22,9 @@ export default function ModelError({
     <Center h="calc(100vh - 3.5rem - 1px)">
       <Box textAlign="center">
         <Heading size="2xl">500</Heading>
-        <Text mt={2}>{error.message || 'An unexpected error occurred.'}</Text>
+        <Text mt={2}>{error.message || t('error.unexpectedError')}</Text>
         <Button mt={4} variant="outline" onClick={reset}>
-          Try again
+          {t('error.tryAgain')}
         </Button>
         <Box mt={2} textDecoration="underline">
           <NextLink href="/models">{t('explorer.returnToModels')}</NextLink>

--- a/src/app/types/summary.ts
+++ b/src/app/types/summary.ts
@@ -90,6 +90,7 @@ export interface ChartRow {
 export interface ErrorRow {
   type: "error";
   label: string;
+  label_pt?: string;
   key: string;
   category?: string;
 }

--- a/src/components/chakra/card.tsx
+++ b/src/components/chakra/card.tsx
@@ -153,7 +153,7 @@ export const DownloadDataCard = ({
               minW={12}
               mr={1}
             >
-              Source
+              {t('downloads.source')}
             </Text>
             <Heading size="sm" color="fg.muted" fontWeight="bold">
               {source}

--- a/src/components/chakra/summary-table.tsx
+++ b/src/components/chakra/summary-table.tsx
@@ -104,10 +104,11 @@ function groupByCategory(
 
 function ErrorRowView({ row }: { row: ErrorRow }) {
   const { t } = useTranslation();
+  const localize = useLocalize();
   return (
     <Table.Row key={row.key} {...summaryRowProps}>
       <Table.Cell {...tableCellStyleProps}>
-        <Text textStyle="tableAttr">{row.label}</Text>
+        <Text textStyle="tableAttr">{localize(row.label, row.label_pt)}</Text>
       </Table.Cell>
       <Table.Cell {...tableCellStyleProps}>
         <Text textStyle="tableValue" textAlign="right" color="fg.error">

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -360,6 +360,7 @@ const ExplorerContent = ({ modelId }: { modelId: string }) => {
     return {
       id: modelCore.id,
       title: modelCore.title,
+      title_pt: modelCore.title_pt,
       scenarios: modelCore.scenarios,
       main: {
         ...modelCore.main,

--- a/src/hooks/use-summary-query.ts
+++ b/src/hooks/use-summary-query.ts
@@ -34,6 +34,7 @@ function transformRows(
       return {
         type: "error" as const,
         label: field.label,
+        label_pt: field.label_pt,
         key: field.columns[0],
         category: field.category,
       };


### PR DESCRIPTION
Adds missing data transformation for translations - the Model `title_pt` in the explorer being most important, along with data transformation and a few localizations for strings that had local translations but were not updating for the language switch/