### PR TITLE
Use API error for login with incorrect credentials

### DIFF
--- a/src/components/layout/login-form.tsx
+++ b/src/components/layout/login-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import axios from 'axios';
 import {
   Box,
   Stack,
@@ -48,7 +49,10 @@ export const LoginModalContent = ({ onSubmit, onClose }: LoginModalProps) => {
       }
       setSuccess(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('auth.login.error', 'Login failed. Please try again.'));
+      const apiMessage = axios.isAxiosError<{ non_field_errors?: string[] }>(err)
+        ? err.response?.data?.non_field_errors?.[0]
+        : undefined;
+      setError(apiMessage ?? t('auth.login.error', 'Login failed. Please try again.'));
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
This code was generated by Claude. Closes #156 
<img width="1764" height="1322" alt="image" src="https://github.com/user-attachments/assets/1bc4e621-c01c-43b5-8ed3-421eeade1b3a" />

Uses axios to ensure that the API response is preferred and used when available.