### PR TITLE
Fix language lag

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import {
   Map,
   ViewStateChangeEvent,
@@ -158,4 +158,4 @@ const MainMap = ({ main, onClick, clusterId, onFlyToRef }: MainMapProps) => {
   );
 };
 
-export default MainMap;
+export default memo(MainMap);

--- a/src/components/ui/control.tsx
+++ b/src/components/ui/control.tsx
@@ -218,6 +218,7 @@ const ControlsPanel = () => {
               defaultValue={["b"]}
               size="sm"
               variant="plain"
+              lazyMount={true}
             >
               {collapsibleGroups.map((group) => (
                 <CollapsibleGroup collapsibleItem={group} key={group.title} />

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -89,6 +89,10 @@ const ExplorerInner = () => {
     setSelected(null);
   }, [setSelected]);
 
+  const onFlyTo = useCallback((lng: number, lat: number) => {
+    flyToRef.current?.(lng, lat);
+  }, []);
+
   useEffect(() => {
     if (selected !== null) {
       openSummary();
@@ -230,7 +234,7 @@ const ExplorerInner = () => {
           clusterId={selected}
           scenarioId={scenarioId}
           onSelectCluster={setSelected}
-          onFlyTo={(lng, lat) => flyToRef.current?.(lng, lat)}
+          onFlyTo={onFlyTo}
           popupFields={model.popupFields}
           summaryFields={model.summaryFields}
           filters={updatedFilters}


### PR DESCRIPTION
Attempts to fix lag on language switcher. This code was generated by claude to memoize map and explorer functions to remove language lag.

This PR:

- Wraps `MainMap` in `React.memo` - it was re-rendering (along with the full MapLibre layer tree) on every language change even though none of its props are translation-dependent.
- Stabilize the `onFlyTo` callback passed to `SummaryPanel` with `useCallback` — it was previously an inline arrow function recreated every render, which silently defeated `SummaryPanel`'s existing `memo()` wrapper.

`ExplorerInner` calls `useTranslation()` for two tooltip labels, which re-renders the whole component on every language switch. Without memoization, that cascaded into a full re-render of the map and summary panel — work neither depends on the active language.