### PR TITLE
Use more proper login message when there is non field message

### DIFF
--- a/src/components/layout/login-form.tsx
+++ b/src/components/layout/login-form.tsx
@@ -11,11 +11,20 @@ import {
 } from '@chakra-ui/react';
 import { LoginResponse } from '@/utils/context/auth';
 import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
 
 interface LoginModalProps {
   onSubmit?: (username: string, password: string) => void | Promise<LoginResponse>;
   onClose?: () => void;
 }
+
+const normalizeErrorMessage = (message: string) =>
+  message.normalize('NFC').toLowerCase().trim();
+
+const NON_FIELD_ERROR_KEYS: Record<string, string> = {
+  [normalizeErrorMessage('Must include "username" and "password".')]: 'auth.login.missingCredentials',
+  [normalizeErrorMessage('Unable to log in with provided credentials.')]: 'auth.login.invalidCredentials',
+};
 
 export const LoginModalContent = ({ onSubmit, onClose }: LoginModalProps) => {
   const [username, setUsername] = useState('');
@@ -48,7 +57,13 @@ export const LoginModalContent = ({ onSubmit, onClose }: LoginModalProps) => {
       }
       setSuccess(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('auth.login.error', 'Login failed. Please try again.'));
+      const nonFieldError = isAxiosError(err) ? err.response?.data?.non_field_errors?.[0] : undefined;
+      const translationKey = nonFieldError && NON_FIELD_ERROR_KEYS[normalizeErrorMessage(nonFieldError)];
+      if (translationKey) {
+        setError(t(translationKey));
+      } else {
+        setError(err instanceof Error ? err.message : t('auth.login.error', 'Login failed. Please try again.'));
+      }
     } finally {
       setIsLoading(false);
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -39,6 +39,8 @@
       "submit": "Sign In",
       "submitting": "Signing in...",
       "validationError": "Please fill in all fields",
+      "missingCredentials": "Must include \"username\" and \"password\".",
+      "invalidCredentials": "Unable to log in with provided credentials.",
       "success": "Login successful!"
     },
     "logout": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -39,6 +39,8 @@
       "submit": "Entrar",
       "submitting": "Entrando...",
       "validationError": "Por favor preencha todos os campos",
+      "missingCredentials": "Deve incluir o \"utilizador\" e a \"senha\".",
+      "invalidCredentials": "Não foi possível entrar com as credenciais fornecidas.",
       "success": "Login realizado com sucesso!"
     },
     "logout": {


### PR DESCRIPTION
Basically this https://github.com/developmentseed/moz-proenergia-web/pull/173 but with pt option. 

- I scraped the message by checking the library that backend is using -(rest-framework?)
- Considering we block the post request missing id + password on UI level  - not sure the first case will be used at all (Must include \"username\" and \"password) but putting it anyway. 