### PR TITLE
Add lang param to keep the selected language across the application.

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { Center, Box, Heading, Text, Button } from '@chakra-ui/react';
-import NextLink from 'next/link';
+import NextLink from '@/components/localized-link';
 import { useTranslation } from 'react-i18next';
 
 export default function AppError({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,9 +43,9 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body>
-        <I18nProvider>
-          <ReactQueryProvider>
-            <NuqsAdapter>
+        <NuqsAdapter>
+          <I18nProvider>
+            <ReactQueryProvider>
               <Provider>
                 <AuthProvider>
                   <TourProvider>
@@ -56,9 +56,9 @@ export default function RootLayout({
                   </TourProvider>
                 </AuthProvider>
               </Provider>
-            </NuqsAdapter>
-          </ReactQueryProvider>
-        </I18nProvider>
+            </ReactQueryProvider>
+          </I18nProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/src/app/model/error.tsx
+++ b/src/app/model/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { Center, Box, Heading, Text, Button } from '@chakra-ui/react';
-import NextLink from 'next/link';
+import NextLink from '@/components/localized-link';
 import { useTranslation } from 'react-i18next';
 
 export default function ModelError({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, Heading, Text, Button, Image, VStack } from "@chakra-ui/react";
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import { useTranslation } from "react-i18next";
 import { LuInfo, LuMap } from "react-icons/lu";
 import { BASE_PATH } from "@/config/website";

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import { Box, Heading, Flex, HStack, Text, Link, Separator, Drawer, CloseButton, IconButton, Portal, VStack, Button } from "@chakra-ui/react";
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import Image from "next/image";
 import { LuBookOpen, LuDownload, LuInfo, LuMap, LuMenu } from "react-icons/lu";
 import DropdownMenu, { DropdownMenuItems } from "./dropdown-menu";

--- a/src/components/layout/header/language-switcher.tsx
+++ b/src/components/layout/header/language-switcher.tsx
@@ -1,13 +1,26 @@
 'use client';
 
+import { Suspense } from 'react';
 import { Button } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
+import { useQueryState } from 'nuqs';
+import { langParser } from '@/i18n/query';
 
-export const LanguageSwitcher = () => {
+function LanguageSwitcherInner() {
   const { i18n } = useTranslation();
   const currentLang = i18n.language?.startsWith('pt') ? 'pt' : 'en';
   const nextLang = currentLang === 'pt' ? 'en' : 'pt';
   const currentFlag = currentLang === 'pt' ? '🇲🇿' : '🇬🇧';
+
+  const [, setLang] = useQueryState(
+    'lang',
+    langParser.withOptions({ history: 'replace', shallow: true }),
+  );
+
+  const handleClick = () => {
+    i18n.changeLanguage(nextLang);
+    setLang(nextLang);
+  };
 
   return (
     <Button
@@ -19,7 +32,7 @@ export const LanguageSwitcher = () => {
       _hover={{ bg: "orange.fg", color: "orange.subtle" }}
       color="inherit"
       minW="auto"
-      onClick={() => i18n.changeLanguage(nextLang)}
+      onClick={handleClick}
       aria-label={`Switch to ${nextLang.toUpperCase()}`}
     >
       {currentFlag}{" "}
@@ -27,3 +40,9 @@ export const LanguageSwitcher = () => {
     </Button>
   );
 };
+
+export const LanguageSwitcher = () => (
+  <Suspense fallback={null}>
+    <LanguageSwitcherInner />
+  </Suspense>
+);

--- a/src/components/layout/landing-models.tsx
+++ b/src/components/layout/landing-models.tsx
@@ -5,7 +5,7 @@ import { Button, Heading, Center, Spinner } from "@chakra-ui/react";
 import { Card } from '@/components/chakra';
 import ReactMarkdown from 'react-markdown';
 
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import { ChakraDrawer } from '@/components/chakra/drawer';
 import { slugify } from '@/utils/data-transformation';
 import { useModels } from '@/hooks/use-models';

--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Box, VStack } from '@chakra-ui/react';
-import Link from 'next/link';
+import Link from '@/components/localized-link';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { createSerializer } from 'nuqs/server';

--- a/src/components/localized-link.tsx
+++ b/src/components/localized-link.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { type ComponentProps } from 'react';
+import NextLink from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { serializeLang, type Language } from '@/i18n/query';
+
+type LocalizedLinkProps = ComponentProps<typeof NextLink>;
+
+// Carries the current `lang` query param forward on page level navigation
+export default function LocalizedLink({ href, ...props }: LocalizedLinkProps) {
+  const { i18n } = useTranslation();
+  const lang: Language = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+
+  const resolvedHref = typeof href === 'string' ? serializeLang(href, { lang }) : href;
+
+  return <NextLink href={resolvedHref} {...props} />;
+}

--- a/src/components/map/summary-panel.tsx
+++ b/src/components/map/summary-panel.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect } from "react";
 import { Box, Flex, Text, IconButton, Link } from "@chakra-ui/react";
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import { api } from "@/utils/api";
 import { slugify } from "@/utils/data-transformation";
 import { useModels } from "@/hooks/use-models";

--- a/src/components/ui/explorer.tsx
+++ b/src/components/ui/explorer.tsx
@@ -9,7 +9,7 @@ import { FiltersProvider } from "@/utils/context/filters";
 import { useFilters } from "@/utils/context/filters";
 import { useModel } from "@/utils/context/model";
 import { Flex, Box, IconButton, Skeleton, Text, Button } from "@chakra-ui/react";
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import MainMap, { type FlyToFn } from "@/components/map";
 import { LuPanelLeftOpen, LuPanelLeftClose, LuPanelRightOpen, LuPanelRightClose } from "react-icons/lu";
 import { useAuth } from "@/utils/context/auth";

--- a/src/components/ui/model-switcher-menu.tsx
+++ b/src/components/ui/model-switcher-menu.tsx
@@ -2,7 +2,7 @@
 
 import { Text, Box, Flex, MenuRoot, Menu, MenuTrigger, MenuContent, MenuItem } from "@chakra-ui/react";
 import Image from "next/image";
-import NextLink from "next/link";
+import NextLink from "@/components/localized-link";
 import { useModel } from "@/utils/context/model";
 import { slugify } from "@/utils/data-transformation";
 import { useModels } from "@/hooks/use-models";

--- a/src/i18n/provider.tsx
+++ b/src/i18n/provider.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, Suspense, useEffect } from 'react';
 import { I18nextProvider, useTranslation } from 'react-i18next';
+import { useQueryState } from 'nuqs';
+import { langParser, type Language } from './query';
 import i18n from './config';
 
 function HtmlLangSync() {
@@ -12,9 +14,36 @@ function HtmlLangSync() {
   return null;
 }
 
+// Applies a `lang` param found in the URL (shared/deep links), and makes sure a
+// page reached without one (e.g. a fresh visit, or navigation that dropped it)
+// picks up the current language.
+function LangUrlSync() {
+  const { i18n } = useTranslation();
+  const currentLang: Language = i18n.language?.startsWith('pt') ? 'pt' : 'en';
+
+  const [urlLang, setUrlLang] = useQueryState(
+    'lang',
+    langParser.withOptions({ history: 'replace', shallow: true }),
+  );
+
+  useEffect(() => {
+    if (urlLang && urlLang !== currentLang) {
+      i18n.changeLanguage(urlLang);
+    } else if (!urlLang) {
+      setUrlLang(currentLang);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlLang]);
+
+  return null;
+}
+
 export function I18nProvider({ children }: { children: ReactNode }) {
   return (
     <I18nextProvider i18n={i18n}>
+      <Suspense fallback={null}>
+        <LangUrlSync />
+      </Suspense>
       <HtmlLangSync />
       {children}
     </I18nextProvider>

--- a/src/i18n/query.ts
+++ b/src/i18n/query.ts
@@ -1,0 +1,8 @@
+import { createSerializer, parseAsStringLiteral } from 'nuqs/server';
+
+export const languages = ['en', 'pt'] as const;
+export type Language = (typeof languages)[number];
+
+export const langParser = parseAsStringLiteral(languages);
+
+export const serializeLang = createSerializer({ lang: langParser });

--- a/src/i18n/query.ts
+++ b/src/i18n/query.ts
@@ -3,6 +3,6 @@ import { createSerializer, parseAsStringLiteral } from 'nuqs/server';
 export const languages = ['en', 'pt'] as const;
 export type Language = (typeof languages)[number];
 
-export const langParser = parseAsStringLiteral(languages);
+export const langParser = parseAsStringLiteral(languages).withDefault(languages[1]);
 
 export const serializeLang = createSerializer({ lang: langParser });

--- a/src/test/app-error.test.tsx
+++ b/src/test/app-error.test.tsx
@@ -2,21 +2,24 @@ import { type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { Provider } from "@/components/chakra/provider";
 import { I18nProvider } from "@/i18n/provider";
 import i18n from "@/i18n/config";
 import AppError from "@/app/error";
 
-vi.mock("next/link", () => ({
+vi.mock("@/components/localized-link", () => ({
   default: ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
 }));
 
 const Wrapper = ({ children }: { children: ReactNode }) => (
-  <Provider>
-    <I18nProvider>{children}</I18nProvider>
-  </Provider>
+  <NuqsTestingAdapter>
+    <Provider>
+      <I18nProvider>{children}</I18nProvider>
+    </Provider>
+  </NuqsTestingAdapter>
 );
 
 beforeEach(() => {

--- a/src/test/error-boundary.test.tsx
+++ b/src/test/error-boundary.test.tsx
@@ -2,15 +2,18 @@ import { type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { Provider } from "@/components/chakra/provider";
 import { I18nProvider } from "@/i18n/provider";
 import i18n from "@/i18n/config";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 const Wrapper = ({ children }: { children: ReactNode }) => (
-  <Provider>
-    <I18nProvider>{children}</I18nProvider>
-  </Provider>
+  <NuqsTestingAdapter>
+    <Provider>
+      <I18nProvider>{children}</I18nProvider>
+    </Provider>
+  </NuqsTestingAdapter>
 );
 
 // Component that throws on render


### PR DESCRIPTION
It had to touch everywhere where `next/link` is used. but the change we needed is the first commit (https://github.com/developmentseed/moz-proenergia-web/pull/184/commits/296a535b3bd096553e11117e74b7b6807f0d8465) and the following commit is just to replace next/link to localized-link. 